### PR TITLE
Feat/매칭구현

### DIFF
--- a/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
@@ -60,7 +60,8 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/api-docs/**",
                                 "/v3/api-docs/**",
-                                "/admin/**"
+                                "/admin/**",
+                                "/privacy.html"
                         ).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.security.web.firewall.HttpFirewall;
 import org.springframework.security.web.firewall.StrictHttpFirewall;
@@ -54,6 +55,7 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**", "/api/health").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/clubs").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",
                                 "/api-docs/**",

--- a/backend/src/main/java/com/pnu/basketball/controller/clubmatch/ClubMatchController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/clubmatch/ClubMatchController.java
@@ -1,0 +1,117 @@
+package com.pnu.basketball.controller.clubmatch;
+
+import com.pnu.basketball.dto.request.ClubMatchCreateRequest;
+import com.pnu.basketball.dto.request.ClubMatchResultRequest;
+import com.pnu.basketball.dto.response.ApiResponse;
+import com.pnu.basketball.dto.response.ClubMatchRequestResponse;
+import com.pnu.basketball.dto.response.ClubMatchResultResponse;
+import com.pnu.basketball.service.clubmatch.ClubMatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/club-matches/requests")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class ClubMatchController {
+
+    private final ClubMatchService clubMatchService;
+
+    @PostMapping
+    @Operation(summary = "친선전 신청 (홈팀 대표)")
+    public ResponseEntity<ApiResponse<ClubMatchRequestResponse>> createRequest(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ClubMatchCreateRequest request) {
+        ClubMatchRequestResponse response = clubMatchService.createRequest(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "친선전 신청이 생성되었습니다."));
+    }
+
+    @PostMapping("/{id}/attend")
+    @Operation(summary = "참가 의사 등록")
+    public ResponseEntity<ApiResponse<Void>> attend(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        clubMatchService.attend(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "참가 의사가 등록되었습니다."));
+    }
+
+    @GetMapping
+    @Operation(summary = "친선전 신청 목록 조회")
+    public ResponseEntity<ApiResponse<Page<ClubMatchRequestResponse>>> getRequests(
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<ClubMatchRequestResponse> response = clubMatchService.getRequests(pageable);
+        return ResponseEntity.ok(ApiResponse.success(response, "친선전 목록 조회 성공"));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "친선전 상세 조회")
+    public ResponseEntity<ApiResponse<ClubMatchRequestResponse>> getDetail(@PathVariable UUID id) {
+        ClubMatchRequestResponse response = clubMatchService.getRequestDetail(id);
+        return ResponseEntity.ok(ApiResponse.success(response, "친선전 상세 조회 성공"));
+    }
+
+    @PostMapping("/{id}/match")
+    @Operation(summary = "상대 동아리 지정 (홈팀 대표)")
+    public ResponseEntity<ApiResponse<ClubMatchRequestResponse>> matchOpponent(
+            @PathVariable UUID id,
+            @RequestParam UUID awayClubId,
+            @AuthenticationPrincipal Long userId) {
+        ClubMatchRequestResponse response = clubMatchService.matchOpponent(id, awayClubId, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "상대 동아리가 지정되었습니다."));
+    }
+
+    @PostMapping("/{id}/confirm")
+    @Operation(summary = "경기 확정 (양팀 5명↑)")
+    public ResponseEntity<ApiResponse<ClubMatchRequestResponse>> confirm(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        ClubMatchRequestResponse response = clubMatchService.confirmMatch(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "경기가 확정되었습니다."));
+    }
+
+    @PostMapping("/{id}/result")
+    @Operation(summary = "결과 입력 (홈팀 대표)")
+    public ResponseEntity<ApiResponse<ClubMatchResultResponse>> submitResult(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ClubMatchResultRequest request) {
+        ClubMatchResultResponse response = clubMatchService.submitResult(id, userId, request);
+        return ResponseEntity.ok(ApiResponse.success(response, "결과가 입력되었습니다."));
+    }
+
+    @PostMapping("/{id}/approve-result")
+    @Operation(summary = "결과 승인 (대표)")
+    public ResponseEntity<ApiResponse<ClubMatchResultResponse>> approveResult(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        ClubMatchResultResponse response = clubMatchService.approveResult(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "결과가 승인되었습니다."));
+    }
+
+    @GetMapping("/admin/pending")
+    @Operation(summary = "관리자: 승인 대기 목록")
+    public ResponseEntity<ApiResponse<List<ClubMatchResultResponse>>> getPendingAdminApproval() {
+        List<ClubMatchResultResponse> response = clubMatchService.getPendingAdminApproval();
+        return ResponseEntity.ok(ApiResponse.success(response, "승인 대기 목록 조회 성공"));
+    }
+
+    @PostMapping("/admin/{id}/confirm")
+    @Operation(summary = "관리자: 최종 기록 확정")
+    public ResponseEntity<ApiResponse<ClubMatchResultResponse>> adminConfirm(@PathVariable UUID id) {
+        ClubMatchResultResponse response = clubMatchService.adminConfirm(id);
+        return ResponseEntity.ok(ApiResponse.success(response, "관리자 최종 확정 완료"));
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/controller/match/MatchController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/match/MatchController.java
@@ -1,10 +1,12 @@
 package com.pnu.basketball.controller.match;
 
-import com.pnu.basketball.dto.response.ApiResponse;
-import com.pnu.basketball.dto.response.MatchResponse;
+import com.pnu.basketball.dto.request.ReviewSubmitRequest;
+import com.pnu.basketball.dto.response.*;
 import com.pnu.basketball.service.match.MatchService;
+import com.pnu.basketball.service.review.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,6 +22,7 @@ import java.util.UUID;
 public class MatchController {
 
     private final MatchService matchService;
+    private final ReviewService reviewService;
 
     @GetMapping
     @Operation(summary = "내 확정 경기 목록")
@@ -34,5 +37,54 @@ public class MatchController {
     public ResponseEntity<ApiResponse<MatchResponse>> getMatch(@PathVariable UUID id) {
         MatchResponse response = matchService.getMatch(id);
         return ResponseEntity.ok(ApiResponse.success(response, "경기 상세 조회 성공"));
+    }
+
+    @PostMapping("/{id}/complete")
+    @Operation(summary = "경기 완료 처리 (모집자/대표/관리자)")
+    public ResponseEntity<ApiResponse<Void>> complete(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        matchService.completeMatch(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "경기가 완료 처리되었습니다."));
+    }
+
+    @GetMapping("/{id}/review-form")
+    @Operation(summary = "리뷰 팝업용 참가자 목록 조회")
+    public ResponseEntity<ApiResponse<ReviewFormResponse>> getReviewForm(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        ReviewFormResponse response = reviewService.getReviewForm(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "리뷰 폼 조회 성공"));
+    }
+
+    @PostMapping("/{id}/review")
+    @Operation(summary = "리뷰 + 노쇼 일괄 제출")
+    public ResponseEntity<ApiResponse<Void>> submitReview(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ReviewSubmitRequest request) {
+        reviewService.submitReview(id, userId, request);
+        return ResponseEntity.ok(ApiResponse.success(null, "리뷰가 제출되었습니다."));
+    }
+
+    @GetMapping("/admin/no-show-reports")
+    @Operation(summary = "관리자: 노쇼 신고 대기 목록")
+    public ResponseEntity<ApiResponse<List<NoShowReportResponse>>> getPendingNoShowReports() {
+        List<NoShowReportResponse> response = reviewService.getPendingNoShowReports();
+        return ResponseEntity.ok(ApiResponse.success(response, "노쇼 신고 목록 조회 성공"));
+    }
+
+    @PostMapping("/admin/no-show-reports/{reportId}/confirm")
+    @Operation(summary = "관리자: 노쇼 확정")
+    public ResponseEntity<ApiResponse<Void>> confirmNoShow(@PathVariable UUID reportId) {
+        reviewService.confirmNoShow(reportId);
+        return ResponseEntity.ok(ApiResponse.success(null, "노쇼가 확정되었습니다."));
+    }
+
+    @PostMapping("/admin/no-show-reports/{reportId}/reject")
+    @Operation(summary = "관리자: 노쇼 반려")
+    public ResponseEntity<ApiResponse<Void>> rejectNoShow(@PathVariable UUID reportId) {
+        reviewService.rejectNoShow(reportId);
+        return ResponseEntity.ok(ApiResponse.success(null, "노쇼 신고가 반려되었습니다."));
     }
 }

--- a/backend/src/main/java/com/pnu/basketball/controller/match/MatchController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/match/MatchController.java
@@ -1,0 +1,38 @@
+package com.pnu.basketball.controller.match;
+
+import com.pnu.basketball.dto.response.ApiResponse;
+import com.pnu.basketball.dto.response.MatchResponse;
+import com.pnu.basketball.service.match.MatchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/matches")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class MatchController {
+
+    private final MatchService matchService;
+
+    @GetMapping
+    @Operation(summary = "내 확정 경기 목록")
+    public ResponseEntity<ApiResponse<List<MatchResponse>>> getMyMatches(
+            @AuthenticationPrincipal Long userId) {
+        List<MatchResponse> response = matchService.getMyMatches(userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "경기 목록 조회 성공"));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "경기 상세 조회")
+    public ResponseEntity<ApiResponse<MatchResponse>> getMatch(@PathVariable UUID id) {
+        MatchResponse response = matchService.getMatch(id);
+        return ResponseEntity.ok(ApiResponse.success(response, "경기 상세 조회 성공"));
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/controller/recruitment/RecruitmentController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/recruitment/RecruitmentController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -49,7 +50,7 @@ public class RecruitmentController {
             @RequestParam(required = false) RecruitmentGameFormat gameFormat,
             @RequestParam(required = false) LocalDateTime startFrom,
             @RequestParam(required = false) LocalDateTime startTo,
-            @PageableDefault(size = 20) Pageable pageable) {
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         Page<RecruitmentListResponse> response = recruitmentService.getList(
                 status, locationId, gameFormat, startFrom, startTo, pageable);
         return ResponseEntity.ok(ApiResponse.success(response, "모집글 목록 조회 성공"));

--- a/backend/src/main/java/com/pnu/basketball/controller/recruitment/RecruitmentController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/recruitment/RecruitmentController.java
@@ -1,0 +1,115 @@
+package com.pnu.basketball.controller.recruitment;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import com.pnu.basketball.dto.request.RecruitmentApplyRequest;
+import com.pnu.basketball.dto.request.RecruitmentCreateRequest;
+import com.pnu.basketball.dto.response.ApiResponse;
+import com.pnu.basketball.dto.response.RecruitmentDetailResponse;
+import com.pnu.basketball.dto.response.RecruitmentListResponse;
+import com.pnu.basketball.service.recruitment.RecruitmentService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/recruitments")
+@RequiredArgsConstructor
+@SecurityRequirement(name = "bearerAuth")
+public class RecruitmentController {
+
+    private final RecruitmentService recruitmentService;
+
+    @PostMapping
+    @Operation(summary = "모집글 생성")
+    public ResponseEntity<ApiResponse<RecruitmentDetailResponse>> create(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RecruitmentCreateRequest request) {
+        RecruitmentDetailResponse response = recruitmentService.create(userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(response, "모집글이 생성되었습니다."));
+    }
+
+    @GetMapping
+    @Operation(summary = "모집글 목록 조회")
+    public ResponseEntity<ApiResponse<Page<RecruitmentListResponse>>> getList(
+            @RequestParam(required = false) RecruitmentStatus status,
+            @RequestParam(required = false) UUID locationId,
+            @RequestParam(required = false) RecruitmentGameFormat gameFormat,
+            @RequestParam(required = false) LocalDateTime startFrom,
+            @RequestParam(required = false) LocalDateTime startTo,
+            @PageableDefault(size = 20) Pageable pageable) {
+        Page<RecruitmentListResponse> response = recruitmentService.getList(
+                status, locationId, gameFormat, startFrom, startTo, pageable);
+        return ResponseEntity.ok(ApiResponse.success(response, "모집글 목록 조회 성공"));
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "모집글 상세 조회")
+    public ResponseEntity<ApiResponse<RecruitmentDetailResponse>> getDetail(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        RecruitmentDetailResponse response = recruitmentService.getDetail(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "모집글 상세 조회 성공"));
+    }
+
+    @PostMapping("/{id}/apply")
+    @Operation(summary = "모집 신청")
+    public ResponseEntity<ApiResponse<Void>> apply(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RecruitmentApplyRequest request) {
+        recruitmentService.apply(id, userId, request);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(null, "신청이 완료되었습니다."));
+    }
+
+    @PostMapping("/{id}/applications/{applicationId}/accept")
+    @Operation(summary = "신청 수락")
+    public ResponseEntity<ApiResponse<Void>> accept(
+            @PathVariable UUID id,
+            @PathVariable UUID applicationId,
+            @AuthenticationPrincipal Long userId) {
+        recruitmentService.acceptApplication(id, applicationId, userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "신청이 수락되었습니다."));
+    }
+
+    @PostMapping("/{id}/applications/{applicationId}/reject")
+    @Operation(summary = "신청 거절")
+    public ResponseEntity<ApiResponse<Void>> reject(
+            @PathVariable UUID id,
+            @PathVariable UUID applicationId,
+            @AuthenticationPrincipal Long userId) {
+        recruitmentService.rejectApplication(id, applicationId, userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "신청이 거절되었습니다."));
+    }
+
+    @PostMapping("/{id}/confirm")
+    @Operation(summary = "모집 확정 → 경기 생성")
+    public ResponseEntity<ApiResponse<RecruitmentDetailResponse>> confirm(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        RecruitmentDetailResponse response = recruitmentService.confirm(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(response, "모집이 확정되고 경기가 생성되었습니다."));
+    }
+
+    @PostMapping("/{id}/cancel")
+    @Operation(summary = "모집 취소")
+    public ResponseEntity<ApiResponse<Void>> cancel(
+            @PathVariable UUID id,
+            @AuthenticationPrincipal Long userId) {
+        recruitmentService.cancel(id, userId);
+        return ResponseEntity.ok(ApiResponse.success(null, "모집이 취소되었습니다."));
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ApplicationStatus.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ApplicationStatus.java
@@ -1,0 +1,7 @@
+package com.pnu.basketball.domain;
+
+public enum ApplicationStatus {
+    PENDING,
+    ACCEPTED,
+    REJECTED
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/Club.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/Club.java
@@ -50,4 +50,8 @@ public class Club {
     public void setCaptain(User captain) {
         this.captain = captain;
     }
+
+    public void incrementWins() {
+        this.wins++;
+    }
 }

--- a/backend/src/main/java/com/pnu/basketball/domain/Club.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/Club.java
@@ -29,6 +29,10 @@ public class Club {
     @Column(name = "introduction", columnDefinition = "TEXT")
     private String introduction;
 
+    @Column(name = "wins", nullable = false)
+    @Builder.Default
+    private int wins = 0;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "captain_id", referencedColumnName = "user_id")
     private User captain;

--- a/backend/src/main/java/com/pnu/basketball/domain/ClubMatchAttendance.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ClubMatchAttendance.java
@@ -1,0 +1,39 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "club_match_attendances",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"request_id", "club_id", "user_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClubMatchAttendance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false)
+    private ClubMatchRequest request;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)
+    private Club club;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ClubMatchRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ClubMatchRequest.java
@@ -1,0 +1,87 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "club_match_requests")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClubMatchRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "home_club_id", nullable = false)
+    private Club homeClub;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private ScheduleLocationEntity location;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ClubMatchStatus status = ClubMatchStatus.GATHERING;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "away_club_id")
+    private Club awayClub;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void ready() {
+        this.status = ClubMatchStatus.READY;
+    }
+
+    public void matchWith(Club awayClub) {
+        this.awayClub = awayClub;
+        this.status = ClubMatchStatus.MATCHED;
+    }
+
+    public void confirm() {
+        this.status = ClubMatchStatus.CONFIRMED;
+    }
+
+    public void done() {
+        this.status = ClubMatchStatus.DONE;
+    }
+
+    public void cancel() {
+        this.status = ClubMatchStatus.CANCELLED;
+    }
+
+    public boolean isHomeClub(UUID clubId) {
+        return this.homeClub.getId().equals(clubId);
+    }
+
+    public boolean isAwayClub(UUID clubId) {
+        return this.awayClub != null && this.awayClub.getId().equals(clubId);
+    }
+
+    public boolean isInvolvedClub(UUID clubId) {
+        return isHomeClub(clubId) || isAwayClub(clubId);
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ClubMatchRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ClubMatchRequest.java
@@ -3,7 +3,9 @@ package com.pnu.basketball.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -36,7 +38,8 @@ public class ClubMatchRequest {
     private ScheduleLocationEntity location;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(nullable = false, columnDefinition = "club_match_status")
     @Builder.Default
     private ClubMatchStatus status = ClubMatchStatus.GATHERING;
 

--- a/backend/src/main/java/com/pnu/basketball/domain/ClubMatchResult.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ClubMatchResult.java
@@ -1,0 +1,73 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "club_match_results")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ClubMatchResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "request_id", nullable = false, unique = true)
+    private ClubMatchRequest request;
+
+    @Column(name = "home_score", nullable = false)
+    private Integer homeScore;
+
+    @Column(name = "away_score", nullable = false)
+    private Integer awayScore;
+
+    @Column(name = "home_approved", nullable = false)
+    @Builder.Default
+    private Boolean homeApproved = false;
+
+    @Column(name = "away_approved", nullable = false)
+    @Builder.Default
+    private Boolean awayApproved = false;
+
+    @Column(name = "admin_approved", nullable = false)
+    @Builder.Default
+    private Boolean adminApproved = false;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void approveHome() {
+        this.homeApproved = true;
+    }
+
+    public void approveAway() {
+        this.awayApproved = true;
+    }
+
+    public void approveAdmin() {
+        this.adminApproved = true;
+    }
+
+    public boolean isBothApproved() {
+        return Boolean.TRUE.equals(homeApproved) && Boolean.TRUE.equals(awayApproved);
+    }
+
+    public boolean isFullyApproved() {
+        return isBothApproved() && Boolean.TRUE.equals(adminApproved);
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ClubMatchStatus.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ClubMatchStatus.java
@@ -1,0 +1,10 @@
+package com.pnu.basketball.domain;
+
+public enum ClubMatchStatus {
+    GATHERING,   // 홈팀 인원 모집 중
+    READY,       // 홈팀 5인 이상 확보, 상대 지정 가능
+    MATCHED,     // 상대팀 지정 완료
+    CONFIRMED,   // 양팀 5인 이상 확보, 일정 확정
+    DONE,        // 경기 종료
+    CANCELLED    // 취소
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/Match.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/Match.java
@@ -1,0 +1,55 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "matches")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Match {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "source_type", nullable = false, length = 20)
+    private MatchSourceType sourceType;
+
+    @Column(name = "recruitment_id")
+    private UUID recruitmentId;
+
+    @Column(name = "club_match_request_id")
+    private UUID clubMatchRequestId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private ScheduleLocationEntity location;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "game_format")
+    private RecruitmentGameFormat gameFormat;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/Match.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/Match.java
@@ -3,7 +3,9 @@ package com.pnu.basketball.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -42,7 +44,8 @@ public class Match {
     private LocalDateTime endAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "game_format")
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(name = "game_format", columnDefinition = "recruitment_game_format")
     private RecruitmentGameFormat gameFormat;
 
     @CreationTimestamp

--- a/backend/src/main/java/com/pnu/basketball/domain/MatchParticipation.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/MatchParticipation.java
@@ -1,0 +1,44 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "match_participations",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"match_id", "user_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MatchParticipation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private ParticipationStatus status = ParticipationStatus.ATTENDED;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public void markNoShow() {
+        this.status = ParticipationStatus.NO_SHOW;
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/MatchSourceType.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/MatchSourceType.java
@@ -1,0 +1,6 @@
+package com.pnu.basketball.domain;
+
+public enum MatchSourceType {
+    RECRUITMENT,
+    CLUB_MATCH
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/NoShowReport.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/NoShowReport.java
@@ -1,0 +1,51 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "no_show_reports")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class NoShowReport {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private NoShowReportStatus status = NoShowReportStatus.PENDING;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public void confirm() {
+        this.status = NoShowReportStatus.CONFIRMED;
+    }
+
+    public void reject() {
+        this.status = NoShowReportStatus.REJECTED;
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/NoShowReportStatus.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/NoShowReportStatus.java
@@ -1,0 +1,7 @@
+package com.pnu.basketball.domain;
+
+public enum NoShowReportStatus {
+    PENDING,
+    CONFIRMED,
+    REJECTED
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ParticipationReview.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ParticipationReview.java
@@ -1,0 +1,39 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "participation_reviews",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"match_id", "reviewer_id", "reviewee_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class ParticipationReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "match_id", nullable = false)
+    private Match match;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id", nullable = false)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id", nullable = false)
+    private User reviewee;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/ParticipationStatus.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/ParticipationStatus.java
@@ -1,0 +1,6 @@
+package com.pnu.basketball.domain;
+
+public enum ParticipationStatus {
+    ATTENDED,
+    NO_SHOW
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/Position.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/Position.java
@@ -1,0 +1,7 @@
+package com.pnu.basketball.domain;
+
+public enum Position {
+    GUARD,
+    FORWARD,
+    CENTER
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentApplication.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentApplication.java
@@ -1,0 +1,51 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "recruitment_applications",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"recruitment_id", "applicant_id"}))
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RecruitmentApplication {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recruitment_id", nullable = false)
+    private RecruitmentPost recruitment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "applicant_id", nullable = false)
+    private User applicant;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private ApplicationStatus status = ApplicationStatus.PENDING;
+
+    @Column(length = 200)
+    private String message;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    public void accept() {
+        this.status = ApplicationStatus.ACCEPTED;
+    }
+
+    public void reject() {
+        this.status = ApplicationStatus.REJECTED;
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentApplication.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentApplication.java
@@ -3,6 +3,8 @@ package com.pnu.basketball.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcType;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -30,7 +32,8 @@ public class RecruitmentApplication {
     private User applicant;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(nullable = false, columnDefinition = "application_status")
     @Builder.Default
     private ApplicationStatus status = ApplicationStatus.PENDING;
 

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentGameFormat.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentGameFormat.java
@@ -1,0 +1,8 @@
+package com.pnu.basketball.domain;
+
+public enum RecruitmentGameFormat {
+    THREE_VS_THREE,
+    FOUR_VS_FOUR,
+    FIVE_VS_FIVE,
+    FLEXIBLE
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
@@ -52,7 +52,8 @@ public class RecruitmentPost {
     private LocalDateTime deadlineAt;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(nullable = false, columnDefinition = "recruitment_status")
     @Builder.Default
     private RecruitmentStatus status = RecruitmentStatus.OPEN;
 

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
@@ -1,0 +1,79 @@
+package com.pnu.basketball.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "recruitment_posts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class RecruitmentPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(updatable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    @Column(name = "start_at", nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(name = "end_at", nullable = false)
+    private LocalDateTime endAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "location_id", nullable = false)
+    private ScheduleLocationEntity location;
+
+    @Column(name = "base_members_count", nullable = false)
+    private Integer baseMembersCount;
+
+    @Column(name = "needed_members", nullable = false)
+    private Integer neededMembers;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "game_format", nullable = false)
+    private RecruitmentGameFormat gameFormat;
+
+    @Column(name = "deadline_at")
+    private LocalDateTime deadlineAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private RecruitmentStatus status = RecruitmentStatus.OPEN;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void confirm() {
+        this.status = RecruitmentStatus.CONFIRMED;
+    }
+
+    public void cancel() {
+        this.status = RecruitmentStatus.CANCELLED;
+    }
+
+    public void close() {
+        this.status = RecruitmentStatus.CLOSED;
+    }
+
+    public boolean isAuthor(Long userId) {
+        return this.author.getUserId().equals(userId);
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentPost.java
@@ -3,7 +3,9 @@ package com.pnu.basketball.domain;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.JdbcType;
 import org.hibernate.annotations.UpdateTimestamp;
+import org.hibernate.dialect.PostgreSQLEnumJdbcType;
 
 import java.time.LocalDateTime;
 import java.util.UUID;
@@ -42,7 +44,8 @@ public class RecruitmentPost {
     private Integer neededMembers;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "game_format", nullable = false)
+    @JdbcType(PostgreSQLEnumJdbcType.class)
+    @Column(name = "game_format", nullable = false, columnDefinition = "recruitment_game_format")
     private RecruitmentGameFormat gameFormat;
 
     @Column(name = "deadline_at")

--- a/backend/src/main/java/com/pnu/basketball/domain/RecruitmentStatus.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/RecruitmentStatus.java
@@ -1,0 +1,8 @@
+package com.pnu.basketball.domain;
+
+public enum RecruitmentStatus {
+    OPEN,
+    CONFIRMED,
+    CLOSED,
+    CANCELLED
+}

--- a/backend/src/main/java/com/pnu/basketball/domain/User.java
+++ b/backend/src/main/java/com/pnu/basketball/domain/User.java
@@ -91,22 +91,47 @@ public class User {
     @Column(name = "fcm_token_updated_at")
     private LocalDateTime fcmTokenUpdatedAt;
 
-    public void updateProfile(String realName, String phoneNumber, String profileImageUrl) {
+    @Column(unique = true, length = 30)
+    private String nickname;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private Position position;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Integer exp = 0;
+
+    @Column(name = "no_show_count", nullable = false)
+    @Builder.Default
+    private Integer noShowCount = 0;
+
+    @Column(name = "participation_count", nullable = false)
+    @Builder.Default
+    private Integer participationCount = 0;
+
+    public void updateProfile(String realName, String phoneNumber, String profileImageUrl,
+                              String nickname, Position position) {
         if (realName != null) this.realName = realName;
         if (phoneNumber != null) this.phoneNumber = phoneNumber;
         if (profileImageUrl != null) this.profileImageUrl = profileImageUrl;
+        if (nickname != null) this.nickname = nickname;
+        if (position != null) this.position = position;
     }
 
     public void updatePassword(String newPassword) {
         this.password = newPassword;
     }
 
-    public void completeProfile(String realName, LocalDate dateOfBirth, Boolean isPnuStudent, String department, String studentId) {
+    public void completeProfile(String realName, LocalDate dateOfBirth, Boolean isPnuStudent,
+                                String department, String studentId, String nickname, Position position) {
         if (realName != null) this.realName = realName;
         if (dateOfBirth != null) this.dateOfBirth = dateOfBirth;
         if (isPnuStudent != null) this.isPnuStudent = isPnuStudent;
         if (department != null) this.department = department;
         if (studentId != null) this.studentId = studentId;
+        if (nickname != null) this.nickname = nickname;
+        if (position != null) this.position = position;
     }
 
     public void verifyPhoneNumber() {
@@ -133,5 +158,17 @@ public class User {
     public void clearFcmToken() {
         this.fcmToken = null;
         this.fcmTokenUpdatedAt = null;
+    }
+
+    public void addExp(int amount) {
+        this.exp += amount;
+    }
+
+    public void incrementParticipationCount() {
+        this.participationCount++;
+    }
+
+    public void incrementNoShowCount() {
+        this.noShowCount++;
     }
 }

--- a/backend/src/main/java/com/pnu/basketball/dto/request/ClubMatchCreateRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/ClubMatchCreateRequest.java
@@ -1,0 +1,24 @@
+package com.pnu.basketball.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class ClubMatchCreateRequest {
+
+    @NotNull(message = "경기 시작 시각은 필수입니다.")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "경기 종료 시각은 필수입니다.")
+    private LocalDateTime endAt;
+
+    @NotNull(message = "장소는 필수입니다.")
+    private UUID locationId;
+
+    private UUID awayClubId;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/request/ClubMatchResultRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/ClubMatchResultRequest.java
@@ -1,0 +1,19 @@
+package com.pnu.basketball.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ClubMatchResultRequest {
+
+    @NotNull(message = "홈팀 점수는 필수입니다.")
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다.")
+    private Integer homeScore;
+
+    @NotNull(message = "원정팀 점수는 필수입니다.")
+    @Min(value = 0, message = "점수는 0 이상이어야 합니다.")
+    private Integer awayScore;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/request/CompleteProfileRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/CompleteProfileRequest.java
@@ -1,5 +1,7 @@
 package com.pnu.basketball.dto.request;
 
+import com.pnu.basketball.domain.Position;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -25,4 +27,11 @@ public class CompleteProfileRequest {
 
     @Size(max = 20, message = "학번은 20자 이내입니다.")
     private String studentId;
+
+    @NotBlank(message = "닉네임은 필수입니다.")
+    @Size(min = 2, max = 30, message = "닉네임은 2-30자 사이여야 합니다.")
+    private String nickname;
+
+    @NotNull(message = "포지션은 필수입니다.")
+    private Position position;
 }

--- a/backend/src/main/java/com/pnu/basketball/dto/request/RecruitmentApplyRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/RecruitmentApplyRequest.java
@@ -1,0 +1,13 @@
+package com.pnu.basketball.dto.request;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RecruitmentApplyRequest {
+
+    @Size(max = 200, message = "메시지는 200자 이내입니다.")
+    private String message;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/request/RecruitmentCreateRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/RecruitmentCreateRequest.java
@@ -1,0 +1,37 @@
+package com.pnu.basketball.dto.request;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+public class RecruitmentCreateRequest {
+
+    @NotNull(message = "경기 시작 시각은 필수입니다.")
+    private LocalDateTime startAt;
+
+    @NotNull(message = "경기 종료 시각은 필수입니다.")
+    private LocalDateTime endAt;
+
+    @NotNull(message = "장소는 필수입니다.")
+    private UUID locationId;
+
+    @NotNull(message = "기본 인원 수는 필수입니다.")
+    @Min(value = 1, message = "기본 인원은 1명 이상이어야 합니다.")
+    private Integer baseMembersCount;
+
+    @NotNull(message = "모집 인원은 필수입니다.")
+    @Min(value = 1, message = "모집 인원은 1명 이상이어야 합니다.")
+    private Integer neededMembers;
+
+    @NotNull(message = "경기 형태는 필수입니다.")
+    private RecruitmentGameFormat gameFormat;
+
+    private LocalDateTime deadlineAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/request/ReviewSubmitRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/ReviewSubmitRequest.java
@@ -1,0 +1,15 @@
+package com.pnu.basketball.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class ReviewSubmitRequest {
+
+    private List<Long> thumbsUpUserIds;
+
+    private List<Long> noShowUserIds;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/request/UpdateProfileRequest.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/request/UpdateProfileRequest.java
@@ -1,5 +1,6 @@
 package com.pnu.basketball.dto.request;
 
+import com.pnu.basketball.domain.Position;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -17,4 +18,9 @@ public class UpdateProfileRequest {
 
     @Size(max = 500, message = "프로필 이미지 URL은 500자를 초과할 수 없습니다.")
     private String profileImageUrl;
+
+    @Size(min = 2, max = 30, message = "닉네임은 2-30자 사이여야 합니다.")
+    private String nickname;
+
+    private Position position;
 }

--- a/backend/src/main/java/com/pnu/basketball/dto/response/ApplicationResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/ApplicationResponse.java
@@ -1,0 +1,28 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.ApplicationStatus;
+import com.pnu.basketball.domain.Position;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApplicationResponse {
+    private UUID applicationId;
+    private Long applicantId;
+    private String applicantNickname;
+    private Position applicantPosition;
+    private Integer applicantExp;
+    private Integer applicantNoShowCount;
+    private Integer applicantParticipationCount;
+    private ApplicationStatus status;
+    private String message;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/ClubListResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/ClubListResponse.java
@@ -21,4 +21,8 @@ public class ClubListResponse {
     private String captainProfileImageUrl;
     /** 내 동아리 조회 시에만 설정. 현재 사용자가 동아리장인지 여부 */
     private Boolean isCaptain;
+    /** 동아리전 승리 수 (club_matches 기준) */
+    private int wins;
+    /** 전체 동아리 순위 (승리 수 기준, 1부터 시작) */
+    private int rank;
 }

--- a/backend/src/main/java/com/pnu/basketball/dto/response/ClubMatchRequestResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/ClubMatchRequestResponse.java
@@ -1,0 +1,29 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.ClubMatchStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClubMatchRequestResponse {
+    private UUID id;
+    private UUID homeClubId;
+    private String homeClubName;
+    private UUID awayClubId;
+    private String awayClubName;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String locationName;
+    private ClubMatchStatus status;
+    private Long homeAttendanceCount;
+    private Long awayAttendanceCount;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/ClubMatchResultResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/ClubMatchResultResponse.java
@@ -1,0 +1,24 @@
+package com.pnu.basketball.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ClubMatchResultResponse {
+    private UUID id;
+    private UUID requestId;
+    private String homeClubName;
+    private String awayClubName;
+    private Integer homeScore;
+    private Integer awayScore;
+    private Boolean homeApproved;
+    private Boolean awayApproved;
+    private Boolean adminApproved;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/MatchResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/MatchResponse.java
@@ -1,0 +1,26 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.MatchSourceType;
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchResponse {
+    private UUID id;
+    private MatchSourceType sourceType;
+    private UUID recruitmentId;
+    private String locationName;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private RecruitmentGameFormat gameFormat;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/NoShowReportResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/NoShowReportResponse.java
@@ -1,0 +1,24 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.NoShowReportStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NoShowReportResponse {
+    private UUID id;
+    private UUID matchId;
+    private String reporterNickname;
+    private Long reportedUserId;
+    private String reportedUserNickname;
+    private NoShowReportStatus status;
+    private LocalDateTime createdAt;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/RecruitmentDetailResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/RecruitmentDetailResponse.java
@@ -1,0 +1,35 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentDetailResponse {
+    private UUID id;
+    private Long authorId;
+    private String authorNickname;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private UUID locationId;
+    private String locationName;
+    private Integer baseMembersCount;
+    private Integer neededMembers;
+    private Long acceptedCount;
+    private RecruitmentGameFormat gameFormat;
+    private RecruitmentStatus status;
+    private LocalDateTime deadlineAt;
+    private LocalDateTime createdAt;
+    private boolean isFull;
+    private List<ApplicationResponse> applications;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/RecruitmentListResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/RecruitmentListResponse.java
@@ -1,0 +1,31 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RecruitmentListResponse {
+    private UUID id;
+    private String authorNickname;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String locationName;
+    private Integer baseMembersCount;
+    private Integer neededMembers;
+    private Long acceptedCount;
+    private RecruitmentGameFormat gameFormat;
+    private RecruitmentStatus status;
+    private LocalDateTime deadlineAt;
+    private LocalDateTime createdAt;
+    private boolean isFull;
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/ReviewFormResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/ReviewFormResponse.java
@@ -1,0 +1,35 @@
+package com.pnu.basketball.dto.response;
+
+import com.pnu.basketball.domain.Position;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewFormResponse {
+    private UUID matchId;
+    private LocalDateTime startAt;
+    private LocalDateTime endAt;
+    private String locationName;
+    private boolean alreadySubmitted;
+    private List<ParticipantInfo> participants;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ParticipantInfo {
+        private Long userId;
+        private String nickname;
+        private Position position;
+        private Integer exp;
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/dto/response/UserResponse.java
+++ b/backend/src/main/java/com/pnu/basketball/dto/response/UserResponse.java
@@ -1,6 +1,7 @@
 package com.pnu.basketball.dto.response;
 
 import com.pnu.basketball.domain.LoginType;
+import com.pnu.basketball.domain.Position;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -25,4 +26,9 @@ public class UserResponse {
     private String department;
     private String studentId;
     private LocalDateTime createdAt;
+    private String nickname;
+    private Position position;
+    private Integer exp;
+    private Integer noShowCount;
+    private Integer participationCount;
 }

--- a/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
+++ b/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // 409 Conflict
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 존재하는 이메일입니다."),
     STUDENT_ID_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 등록된 학번입니다."),
+    NICKNAME_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 닉네임입니다."),
 
     // Club
     CLUB_NOT_FOUND(HttpStatus.NOT_FOUND, "동아리를 찾을 수 없습니다."),

--- a/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
+++ b/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
@@ -47,6 +47,22 @@ public enum ErrorCode {
     UNAUTHORIZED_POST_EDIT(HttpStatus.FORBIDDEN, "본인의 게시글만 수정/삭제할 수 있습니다."),
     UNAUTHORIZED_COMMENT_EDIT(HttpStatus.FORBIDDEN, "본인의 댓글만 수정/삭제할 수 있습니다."),
 
+    // Recruitment
+    RECRUITMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "모집글을 찾을 수 없습니다."),
+    RECRUITMENT_NOT_OPEN(HttpStatus.BAD_REQUEST, "모집 중인 글이 아닙니다."),
+    RECRUITMENT_ALREADY_APPLIED(HttpStatus.CONFLICT, "이미 신청한 모집글입니다."),
+    RECRUITMENT_SELF_APPLY(HttpStatus.BAD_REQUEST, "본인의 모집글에는 신청할 수 없습니다."),
+    RECRUITMENT_NOT_AUTHOR(HttpStatus.FORBIDDEN, "모집글 작성자만 수행할 수 있습니다."),
+    APPLICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "신청 내역을 찾을 수 없습니다."),
+    APPLICATION_NOT_PENDING(HttpStatus.BAD_REQUEST, "대기 중인 신청만 처리할 수 있습니다."),
+    RECRUITMENT_INVALID_TIME(HttpStatus.BAD_REQUEST, "경기 시작 시각은 종료 시각보다 앞이어야 합니다."),
+    RECRUITMENT_PAST_TIME(HttpStatus.BAD_REQUEST, "과거 시각으로 모집글을 생성할 수 없습니다."),
+
+    // Match
+    MATCH_NOT_FOUND(HttpStatus.NOT_FOUND, "경기를 찾을 수 없습니다."),
+    MATCH_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 확정된 경기가 존재합니다."),
+    MATCH_COMPLETE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "경기 완료 처리 권한이 없습니다."),
+
     // Schedule
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
     SCHEDULE_OVERLAP(HttpStatus.CONFLICT, "해당 장소의 같은 날짜·시간대에 이미 일정이 등록되어 있습니다."),

--- a/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
+++ b/backend/src/main/java/com/pnu/basketball/exception/ErrorCode.java
@@ -63,6 +63,24 @@ public enum ErrorCode {
     MATCH_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 확정된 경기가 존재합니다."),
     MATCH_COMPLETE_UNAUTHORIZED(HttpStatus.FORBIDDEN, "경기 완료 처리 권한이 없습니다."),
 
+    // Club Match
+    CLUB_MATCH_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "친선전 신청을 찾을 수 없습니다."),
+    CLUB_MATCH_NOT_CLUB_MEMBER(HttpStatus.FORBIDDEN, "동아리 소속 멤버만 가능합니다."),
+    CLUB_MATCH_NOT_CAPTAIN(HttpStatus.FORBIDDEN, "동아리 대표만 수행할 수 있습니다."),
+    CLUB_MATCH_ALREADY_ATTENDED(HttpStatus.CONFLICT, "이미 참가 의사를 등록했습니다."),
+    CLUB_MATCH_NOT_READY(HttpStatus.BAD_REQUEST, "상대 지정이 불가한 상태입니다."),
+    CLUB_MATCH_SAME_CLUB(HttpStatus.BAD_REQUEST, "같은 동아리를 상대로 지정할 수 없습니다."),
+    CLUB_MATCH_RESULT_EXISTS(HttpStatus.CONFLICT, "이미 결과가 입력되었습니다."),
+    CLUB_MATCH_NOT_DONE(HttpStatus.BAD_REQUEST, "경기가 완료 상태가 아닙니다."),
+    CLUB_MATCH_NOT_INVOLVED(HttpStatus.FORBIDDEN, "해당 친선전에 참여한 동아리가 아닙니다."),
+    CLUB_MATCH_RESULT_NOT_FOUND(HttpStatus.NOT_FOUND, "경기 결과를 찾을 수 없습니다."),
+
+    // Review & NoShow
+    REVIEW_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "리뷰 제출 기한(24시간)이 지났습니다."),
+    REVIEW_NOT_PARTICIPANT(HttpStatus.FORBIDDEN, "해당 경기 참가자만 리뷰할 수 있습니다."),
+    REVIEW_ALREADY_SUBMITTED(HttpStatus.CONFLICT, "이미 리뷰를 제출했습니다."),
+    NO_SHOW_REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "노쇼 신고를 찾을 수 없습니다."),
+
     // Schedule
     SCHEDULE_NOT_FOUND(HttpStatus.NOT_FOUND, "일정을 찾을 수 없습니다."),
     SCHEDULE_OVERLAP(HttpStatus.CONFLICT, "해당 장소의 같은 날짜·시간대에 이미 일정이 등록되어 있습니다."),

--- a/backend/src/main/java/com/pnu/basketball/repository/ClubMatchAttendanceRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/ClubMatchAttendanceRepository.java
@@ -1,0 +1,18 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.ClubMatchAttendance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ClubMatchAttendanceRepository extends JpaRepository<ClubMatchAttendance, UUID> {
+
+    long countByRequestIdAndClubId(UUID requestId, UUID clubId);
+
+    List<ClubMatchAttendance> findByRequestIdAndClubId(UUID requestId, UUID clubId);
+
+    boolean existsByRequestIdAndClubIdAndUserUserId(UUID requestId, UUID clubId, Long userId);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/ClubMatchRequestRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/ClubMatchRequestRepository.java
@@ -1,0 +1,24 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.ClubMatchRequest;
+import com.pnu.basketball.domain.ClubMatchStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ClubMatchRequestRepository extends JpaRepository<ClubMatchRequest, UUID> {
+
+    Page<ClubMatchRequest> findByStatusInOrderByCreatedAtDesc(List<ClubMatchStatus> statuses, Pageable pageable);
+
+    @Query("SELECT r FROM ClubMatchRequest r WHERE r.homeClub.id = :clubId OR r.awayClub.id = :clubId ORDER BY r.createdAt DESC")
+    Page<ClubMatchRequest> findByClubId(@Param("clubId") UUID clubId, Pageable pageable);
+
+    List<ClubMatchRequest> findByStatusOrderByCreatedAtDesc(ClubMatchStatus status);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/ClubMatchResultRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/ClubMatchResultRepository.java
@@ -1,0 +1,19 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.ClubMatchResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface ClubMatchResultRepository extends JpaRepository<ClubMatchResult, UUID> {
+
+    Optional<ClubMatchResult> findByRequestId(UUID requestId);
+
+    @Query("SELECT r FROM ClubMatchResult r WHERE r.homeApproved = true AND r.awayApproved = true AND r.adminApproved = false")
+    List<ClubMatchResult> findPendingAdminApproval();
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/ClubRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/ClubRepository.java
@@ -9,4 +9,7 @@ import java.util.UUID;
 @Repository
 public interface ClubRepository extends JpaRepository<Club, UUID> {
     boolean existsByName(String name);
+
+    /** 승리 수 기준 내림차순 정렬 (순위용) */
+    java.util.List<Club> findAllByOrderByWinsDesc();
 }

--- a/backend/src/main/java/com/pnu/basketball/repository/MatchParticipationRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/MatchParticipationRepository.java
@@ -1,0 +1,16 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.MatchParticipation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface MatchParticipationRepository extends JpaRepository<MatchParticipation, UUID> {
+
+    List<MatchParticipation> findByMatchId(UUID matchId);
+
+    boolean existsByMatchIdAndUserUserId(UUID matchId, Long userId);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/MatchRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/MatchRepository.java
@@ -1,0 +1,21 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.Match;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface MatchRepository extends JpaRepository<Match, UUID> {
+
+    Optional<Match> findByRecruitmentId(UUID recruitmentId);
+
+    @Query("SELECT m FROM Match m JOIN MatchParticipation mp ON mp.match.id = m.id " +
+            "WHERE mp.user.userId = :userId ORDER BY m.startAt DESC")
+    List<Match> findByParticipantUserId(@Param("userId") Long userId);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/NoShowReportRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/NoShowReportRepository.java
@@ -1,0 +1,21 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.NoShowReport;
+import com.pnu.basketball.domain.NoShowReportStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface NoShowReportRepository extends JpaRepository<NoShowReport, UUID> {
+
+    List<NoShowReport> findByMatchId(UUID matchId);
+
+    List<NoShowReport> findByStatus(NoShowReportStatus status);
+
+    boolean existsByMatchIdAndReporterUserIdAndReportedUserUserId(UUID matchId, Long reporterId, Long reportedUserId);
+
+    long countByMatchIdAndReportedUserUserId(UUID matchId, Long reportedUserId);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/ParticipationReviewRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/ParticipationReviewRepository.java
@@ -1,0 +1,18 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.ParticipationReview;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface ParticipationReviewRepository extends JpaRepository<ParticipationReview, UUID> {
+
+    List<ParticipationReview> findByMatchId(UUID matchId);
+
+    boolean existsByMatchIdAndReviewerUserIdAndRevieweeUserId(UUID matchId, Long reviewerId, Long revieweeId);
+
+    long countByRevieweeUserId(Long revieweeId);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/RecruitmentApplicationRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/RecruitmentApplicationRepository.java
@@ -1,0 +1,24 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.ApplicationStatus;
+import com.pnu.basketball.domain.RecruitmentApplication;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface RecruitmentApplicationRepository extends JpaRepository<RecruitmentApplication, UUID> {
+
+    List<RecruitmentApplication> findByRecruitmentId(UUID recruitmentId);
+
+    List<RecruitmentApplication> findByRecruitmentIdAndStatus(UUID recruitmentId, ApplicationStatus status);
+
+    Optional<RecruitmentApplication> findByRecruitmentIdAndApplicantUserId(UUID recruitmentId, Long applicantId);
+
+    boolean existsByRecruitmentIdAndApplicantUserId(UUID recruitmentId, Long applicantId);
+
+    long countByRecruitmentIdAndStatus(UUID recruitmentId, ApplicationStatus status);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/RecruitmentPostRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/RecruitmentPostRepository.java
@@ -1,0 +1,34 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.RecruitmentPost;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Repository
+public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost, UUID> {
+
+    @Query("SELECT r FROM RecruitmentPost r " +
+            "WHERE (:status IS NULL OR r.status = :status) " +
+            "AND (:locationId IS NULL OR r.location.id = :locationId) " +
+            "AND (:gameFormat IS NULL OR r.gameFormat = :gameFormat) " +
+            "AND (:startFrom IS NULL OR r.startAt >= :startFrom) " +
+            "AND (:startTo IS NULL OR r.startAt <= :startTo) " +
+            "ORDER BY r.createdAt DESC")
+    Page<RecruitmentPost> findAllWithFilters(
+            @Param("status") RecruitmentStatus status,
+            @Param("locationId") UUID locationId,
+            @Param("gameFormat") com.pnu.basketball.domain.RecruitmentGameFormat gameFormat,
+            @Param("startFrom") LocalDateTime startFrom,
+            @Param("startTo") LocalDateTime startTo,
+            Pageable pageable);
+
+    Page<RecruitmentPost> findByAuthorUserIdOrderByCreatedAtDesc(Long authorId, Pageable pageable);
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/RecruitmentPostRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/RecruitmentPostRepository.java
@@ -1,34 +1,17 @@
 package com.pnu.basketball.repository;
 
 import com.pnu.basketball.domain.RecruitmentPost;
-import com.pnu.basketball.domain.RecruitmentStatus;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.time.LocalDateTime;
 import java.util.UUID;
 
 @Repository
-public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost, UUID> {
-
-    @Query("SELECT r FROM RecruitmentPost r " +
-            "WHERE (:status IS NULL OR r.status = :status) " +
-            "AND (:locationId IS NULL OR r.location.id = :locationId) " +
-            "AND (:gameFormat IS NULL OR r.gameFormat = :gameFormat) " +
-            "AND (:startFrom IS NULL OR r.startAt >= :startFrom) " +
-            "AND (:startTo IS NULL OR r.startAt <= :startTo) " +
-            "ORDER BY r.createdAt DESC")
-    Page<RecruitmentPost> findAllWithFilters(
-            @Param("status") RecruitmentStatus status,
-            @Param("locationId") UUID locationId,
-            @Param("gameFormat") com.pnu.basketball.domain.RecruitmentGameFormat gameFormat,
-            @Param("startFrom") LocalDateTime startFrom,
-            @Param("startTo") LocalDateTime startTo,
-            Pageable pageable);
+public interface RecruitmentPostRepository extends JpaRepository<RecruitmentPost, UUID>,
+        JpaSpecificationExecutor<RecruitmentPost> {
 
     Page<RecruitmentPost> findByAuthorUserIdOrderByCreatedAtDesc(Long authorId, Pageable pageable);
 }

--- a/backend/src/main/java/com/pnu/basketball/repository/RecruitmentSpecification.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/RecruitmentSpecification.java
@@ -1,0 +1,61 @@
+package com.pnu.basketball.repository;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import com.pnu.basketball.domain.RecruitmentPost;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * PostgreSQL "could not determine data type of parameter" 오류 방지:
+ * null 파라미터를 WHERE 절에 전달하지 않고, Specification으로 동적 쿼리 구성.
+ */
+public final class RecruitmentSpecification {
+
+    private RecruitmentSpecification() {
+    }
+
+    public static Specification<RecruitmentPost> withFilters(
+            RecruitmentStatus status,
+            UUID locationId,
+            RecruitmentGameFormat gameFormat,
+            LocalDateTime startFrom,
+            LocalDateTime startTo) {
+        return Specification
+                .where(statusEquals(status))
+                .and(locationIdEquals(locationId))
+                .and(gameFormatEquals(gameFormat))
+                .and(startAtAfterOrEqual(startFrom))
+                .and(startAtBeforeOrEqual(startTo));
+    }
+
+    private static Specification<RecruitmentPost> statusEquals(RecruitmentStatus status) {
+        return (root, query, cb) -> status == null ? cb.conjunction() : cb.equal(root.get("status"), status);
+    }
+
+    private static Specification<RecruitmentPost> locationIdEquals(UUID locationId) {
+        return (root, query, cb) -> locationId == null
+                ? cb.conjunction()
+                : cb.equal(root.get("location").get("id"), locationId);
+    }
+
+    private static Specification<RecruitmentPost> gameFormatEquals(RecruitmentGameFormat gameFormat) {
+        return (root, query, cb) -> gameFormat == null
+                ? cb.conjunction()
+                : cb.equal(root.get("gameFormat"), gameFormat);
+    }
+
+    private static Specification<RecruitmentPost> startAtAfterOrEqual(LocalDateTime startFrom) {
+        return (root, query, cb) -> startFrom == null
+                ? cb.conjunction()
+                : cb.greaterThanOrEqualTo(root.get("startAt"), startFrom);
+    }
+
+    private static Specification<RecruitmentPost> startAtBeforeOrEqual(LocalDateTime startTo) {
+        return (root, query, cb) -> startTo == null
+                ? cb.conjunction()
+                : cb.lessThanOrEqualTo(root.get("startAt"), startTo);
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/repository/UserRepository.java
+++ b/backend/src/main/java/com/pnu/basketball/repository/UserRepository.java
@@ -25,6 +25,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByKakaoId(String kakaoId);
     boolean existsByStudentId(String studentId);
     boolean existsByStudentIdAndUserIdNot(String studentId, Long userId);
+    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndUserIdNot(String nickname, Long userId);
 
     @Query("SELECT u FROM User u " +
             "WHERE (:isPnuStudent IS NULL OR u.isPnuStudent = :isPnuStudent) " +

--- a/backend/src/main/java/com/pnu/basketball/service/club/ClubServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/club/ClubServiceImpl.java
@@ -34,9 +34,13 @@ public class ClubServiceImpl implements ClubService {
     @Override
     @Transactional(readOnly = true)
     public List<ClubListResponse> getClubs() {
-        return clubRepository.findAll().stream()
-                .map(club -> toClubListResponse(club, null))
-                .collect(Collectors.toList());
+        List<Club> clubs = clubRepository.findAllByOrderByWinsDesc();
+        int rank = 1;
+        List<ClubListResponse> result = new java.util.ArrayList<>();
+        for (Club club : clubs) {
+            result.add(toClubListResponseWithRank(club, null, rank++));
+        }
+        return result;
     }
 
     @Override
@@ -163,6 +167,10 @@ public class ClubServiceImpl implements ClubService {
     }
 
     private ClubListResponse toClubListResponse(Club club, Long currentUserId) {
+        return toClubListResponseWithRank(club, currentUserId, 0);
+    }
+
+    private ClubListResponse toClubListResponseWithRank(Club club, Long currentUserId, int rank) {
         String captainName = null;
         String captainProfileImageUrl = null;
         Boolean isCaptain = null;
@@ -182,6 +190,8 @@ public class ClubServiceImpl implements ClubService {
                 .captainName(captainName)
                 .captainProfileImageUrl(captainProfileImageUrl)
                 .isCaptain(isCaptain)
+                .wins(club.getWins())
+                .rank(rank)
                 .build();
     }
 }

--- a/backend/src/main/java/com/pnu/basketball/service/clubmatch/ClubMatchService.java
+++ b/backend/src/main/java/com/pnu/basketball/service/clubmatch/ClubMatchService.java
@@ -1,0 +1,34 @@
+package com.pnu.basketball.service.clubmatch;
+
+import com.pnu.basketball.dto.request.ClubMatchCreateRequest;
+import com.pnu.basketball.dto.request.ClubMatchResultRequest;
+import com.pnu.basketball.dto.response.ClubMatchRequestResponse;
+import com.pnu.basketball.dto.response.ClubMatchResultResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ClubMatchService {
+
+    ClubMatchRequestResponse createRequest(Long userId, ClubMatchCreateRequest request);
+
+    void attend(UUID requestId, Long userId);
+
+    Page<ClubMatchRequestResponse> getRequests(Pageable pageable);
+
+    ClubMatchRequestResponse getRequestDetail(UUID requestId);
+
+    ClubMatchRequestResponse matchOpponent(UUID requestId, UUID awayClubId, Long userId);
+
+    ClubMatchRequestResponse confirmMatch(UUID requestId, Long userId);
+
+    ClubMatchResultResponse submitResult(UUID requestId, Long userId, ClubMatchResultRequest request);
+
+    ClubMatchResultResponse approveResult(UUID requestId, Long userId);
+
+    List<ClubMatchResultResponse> getPendingAdminApproval();
+
+    ClubMatchResultResponse adminConfirm(UUID requestId);
+}

--- a/backend/src/main/java/com/pnu/basketball/service/clubmatch/ClubMatchServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/clubmatch/ClubMatchServiceImpl.java
@@ -1,0 +1,328 @@
+package com.pnu.basketball.service.clubmatch;
+
+import com.pnu.basketball.domain.*;
+import com.pnu.basketball.dto.request.ClubMatchCreateRequest;
+import com.pnu.basketball.dto.request.ClubMatchResultRequest;
+import com.pnu.basketball.dto.response.ClubMatchRequestResponse;
+import com.pnu.basketball.dto.response.ClubMatchResultResponse;
+import com.pnu.basketball.exception.CustomException;
+import com.pnu.basketball.exception.ErrorCode;
+import com.pnu.basketball.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ClubMatchServiceImpl implements ClubMatchService {
+
+    private static final int MIN_ATTENDANCE = 5;
+
+    private final ClubMatchRequestRepository requestRepository;
+    private final ClubMatchAttendanceRepository attendanceRepository;
+    private final ClubMatchResultRepository resultRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final ClubRepository clubRepository;
+    private final UserRepository userRepository;
+    private final ScheduleLocationRepository locationRepository;
+    private final MatchRepository matchRepository;
+    private final MatchParticipationRepository matchParticipationRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Override
+    @Transactional
+    public ClubMatchRequestResponse createRequest(Long userId, ClubMatchCreateRequest request) {
+        ClubMember member = getClubMember(userId);
+        if (member.getRole() != ClubRole.PRESIDENT) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_CAPTAIN);
+        }
+
+        ScheduleLocationEntity location = locationRepository.findById(request.getLocationId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SCHEDULE_LOCATION_NOT_FOUND));
+
+        ClubMatchRequest matchRequest = ClubMatchRequest.builder()
+                .homeClub(member.getClub())
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
+                .location(location)
+                .build();
+        requestRepository.save(matchRequest);
+
+        return toResponse(matchRequest);
+    }
+
+    @Override
+    @Transactional
+    public void attend(UUID requestId, Long userId) {
+        ClubMatchRequest request = findRequest(requestId);
+        ClubMember member = getClubMember(userId);
+        UUID clubId = member.getClub().getId();
+
+        if (!request.isHomeClub(clubId) && !request.isAwayClub(clubId)) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_INVOLVED);
+        }
+
+        if (attendanceRepository.existsByRequestIdAndClubIdAndUserUserId(requestId, clubId, userId)) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_ALREADY_ATTENDED);
+        }
+
+        ClubMatchAttendance attendance = ClubMatchAttendance.builder()
+                .request(request)
+                .club(member.getClub())
+                .user(member.getUser())
+                .build();
+        attendanceRepository.save(attendance);
+
+        long homeCount = attendanceRepository.countByRequestIdAndClubId(requestId, request.getHomeClub().getId());
+        if (request.getStatus() == ClubMatchStatus.GATHERING && homeCount >= MIN_ATTENDANCE) {
+            request.ready();
+        }
+
+        if (request.getStatus() == ClubMatchStatus.MATCHED && request.getAwayClub() != null) {
+            long awayCount = attendanceRepository.countByRequestIdAndClubId(requestId, request.getAwayClub().getId());
+            if (homeCount >= MIN_ATTENDANCE && awayCount >= MIN_ATTENDANCE) {
+                request.confirm();
+                createMatchAndSchedule(request);
+            }
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<ClubMatchRequestResponse> getRequests(Pageable pageable) {
+        return requestRepository.findByStatusInOrderByCreatedAtDesc(
+                List.of(ClubMatchStatus.GATHERING, ClubMatchStatus.READY, ClubMatchStatus.MATCHED,
+                        ClubMatchStatus.CONFIRMED, ClubMatchStatus.DONE),
+                pageable).map(this::toResponse);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public ClubMatchRequestResponse getRequestDetail(UUID requestId) {
+        return toResponse(findRequest(requestId));
+    }
+
+    @Override
+    @Transactional
+    public ClubMatchRequestResponse matchOpponent(UUID requestId, UUID awayClubId, Long userId) {
+        ClubMatchRequest request = findRequest(requestId);
+
+        ClubMember member = getClubMember(userId);
+        if (member.getRole() != ClubRole.PRESIDENT || !request.isHomeClub(member.getClub().getId())) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_CAPTAIN);
+        }
+
+        if (request.getStatus() != ClubMatchStatus.READY) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_READY);
+        }
+        if (request.getHomeClub().getId().equals(awayClubId)) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_SAME_CLUB);
+        }
+
+        Club awayClub = clubRepository.findById(awayClubId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_NOT_FOUND));
+
+        request.matchWith(awayClub);
+        return toResponse(request);
+    }
+
+    @Override
+    @Transactional
+    public ClubMatchRequestResponse confirmMatch(UUID requestId, Long userId) {
+        ClubMatchRequest request = findRequest(requestId);
+
+        if (request.getStatus() != ClubMatchStatus.MATCHED) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "MATCHED 상태에서만 확정할 수 있습니다.");
+        }
+
+        long homeCount = attendanceRepository.countByRequestIdAndClubId(requestId, request.getHomeClub().getId());
+        long awayCount = attendanceRepository.countByRequestIdAndClubId(requestId, request.getAwayClub().getId());
+        if (homeCount < MIN_ATTENDANCE || awayCount < MIN_ATTENDANCE) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "양팀 모두 5명 이상 참가해야 확정할 수 있습니다.");
+        }
+
+        request.confirm();
+        createMatchAndSchedule(request);
+        return toResponse(request);
+    }
+
+    @Override
+    @Transactional
+    public ClubMatchResultResponse submitResult(UUID requestId, Long userId, ClubMatchResultRequest resultReq) {
+        ClubMatchRequest request = findRequest(requestId);
+
+        if (request.getStatus() != ClubMatchStatus.CONFIRMED && request.getStatus() != ClubMatchStatus.DONE) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_DONE);
+        }
+
+        if (resultRepository.findByRequestId(requestId).isPresent()) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_RESULT_EXISTS);
+        }
+
+        ClubMember member = getClubMember(userId);
+        if (member.getRole() != ClubRole.PRESIDENT || !request.isHomeClub(member.getClub().getId())) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_CAPTAIN);
+        }
+
+        request.done();
+
+        ClubMatchResult result = ClubMatchResult.builder()
+                .request(request)
+                .homeScore(resultReq.getHomeScore())
+                .awayScore(resultReq.getAwayScore())
+                .homeApproved(true)
+                .build();
+        resultRepository.save(result);
+
+        return toResultResponse(result, request);
+    }
+
+    @Override
+    @Transactional
+    public ClubMatchResultResponse approveResult(UUID requestId, Long userId) {
+        ClubMatchRequest request = findRequest(requestId);
+        ClubMatchResult result = resultRepository.findByRequestId(requestId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MATCH_RESULT_NOT_FOUND));
+
+        ClubMember member = getClubMember(userId);
+        if (member.getRole() != ClubRole.PRESIDENT) {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_CAPTAIN);
+        }
+
+        UUID clubId = member.getClub().getId();
+        if (request.isHomeClub(clubId)) {
+            result.approveHome();
+        } else if (request.isAwayClub(clubId)) {
+            result.approveAway();
+        } else {
+            throw new CustomException(ErrorCode.CLUB_MATCH_NOT_INVOLVED);
+        }
+
+        return toResultResponse(result, request);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClubMatchResultResponse> getPendingAdminApproval() {
+        return resultRepository.findPendingAdminApproval().stream()
+                .map(r -> toResultResponse(r, r.getRequest()))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public ClubMatchResultResponse adminConfirm(UUID requestId) {
+        ClubMatchResult result = resultRepository.findByRequestId(requestId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MATCH_RESULT_NOT_FOUND));
+
+        if (!result.isBothApproved()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT, "양팀 대표 승인이 완료되지 않았습니다.");
+        }
+
+        result.approveAdmin();
+
+        ClubMatchRequest request = result.getRequest();
+        Club homeClub = request.getHomeClub();
+        Club awayClub = request.getAwayClub();
+
+        if (result.getHomeScore() > result.getAwayScore()) {
+            homeClub.incrementWins();
+        } else if (result.getAwayScore() > result.getHomeScore()) {
+            awayClub.incrementWins();
+        }
+
+        return toResultResponse(result, request);
+    }
+
+    private void createMatchAndSchedule(ClubMatchRequest request) {
+        Match match = Match.builder()
+                .sourceType(MatchSourceType.CLUB_MATCH)
+                .clubMatchRequestId(request.getId())
+                .location(request.getLocation())
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
+                .build();
+        matchRepository.save(match);
+
+        String title = "동아리전: " + request.getHomeClub().getName()
+                + " vs " + (request.getAwayClub() != null ? request.getAwayClub().getName() : "TBD");
+
+        Schedule schedule = Schedule.builder()
+                .location(request.getLocation())
+                .scheduleDate(request.getStartAt().toLocalDate())
+                .startTime(request.getStartAt().toLocalTime())
+                .endTime(request.getEndAt().toLocalTime())
+                .status(ScheduleStatus.SCHEDULED)
+                .scheduleType("MATCH")
+                .title(title)
+                .matchId(match.getId())
+                .build();
+        scheduleRepository.save(schedule);
+
+        List<ClubMatchAttendance> homeAttendances = attendanceRepository
+                .findByRequestIdAndClubId(request.getId(), request.getHomeClub().getId());
+        List<ClubMatchAttendance> awayAttendances = request.getAwayClub() != null
+                ? attendanceRepository.findByRequestIdAndClubId(request.getId(), request.getAwayClub().getId())
+                : List.of();
+
+        for (ClubMatchAttendance att : homeAttendances) {
+            matchParticipationRepository.save(MatchParticipation.builder()
+                    .match(match).user(att.getUser()).status(ParticipationStatus.ATTENDED).build());
+        }
+        for (ClubMatchAttendance att : awayAttendances) {
+            matchParticipationRepository.save(MatchParticipation.builder()
+                    .match(match).user(att.getUser()).status(ParticipationStatus.ATTENDED).build());
+        }
+    }
+
+    private ClubMatchRequest findRequest(UUID id) {
+        return requestRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MATCH_REQUEST_NOT_FOUND));
+    }
+
+    private ClubMember getClubMember(Long userId) {
+        return clubMemberRepository.findByUserUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CLUB_MATCH_NOT_CLUB_MEMBER));
+    }
+
+    private ClubMatchRequestResponse toResponse(ClubMatchRequest req) {
+        long homeCount = attendanceRepository.countByRequestIdAndClubId(req.getId(), req.getHomeClub().getId());
+        long awayCount = req.getAwayClub() != null
+                ? attendanceRepository.countByRequestIdAndClubId(req.getId(), req.getAwayClub().getId()) : 0;
+
+        return ClubMatchRequestResponse.builder()
+                .id(req.getId())
+                .homeClubId(req.getHomeClub().getId())
+                .homeClubName(req.getHomeClub().getName())
+                .awayClubId(req.getAwayClub() != null ? req.getAwayClub().getId() : null)
+                .awayClubName(req.getAwayClub() != null ? req.getAwayClub().getName() : null)
+                .startAt(req.getStartAt())
+                .endAt(req.getEndAt())
+                .locationName(req.getLocation().getName())
+                .status(req.getStatus())
+                .homeAttendanceCount(homeCount)
+                .awayAttendanceCount(awayCount)
+                .createdAt(req.getCreatedAt())
+                .build();
+    }
+
+    private ClubMatchResultResponse toResultResponse(ClubMatchResult result, ClubMatchRequest request) {
+        return ClubMatchResultResponse.builder()
+                .id(result.getId())
+                .requestId(request.getId())
+                .homeClubName(request.getHomeClub().getName())
+                .awayClubName(request.getAwayClub() != null ? request.getAwayClub().getName() : null)
+                .homeScore(result.getHomeScore())
+                .awayScore(result.getAwayScore())
+                .homeApproved(result.getHomeApproved())
+                .awayApproved(result.getAwayApproved())
+                .adminApproved(result.getAdminApproved())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/service/match/MatchService.java
+++ b/backend/src/main/java/com/pnu/basketball/service/match/MatchService.java
@@ -1,0 +1,13 @@
+package com.pnu.basketball.service.match;
+
+import com.pnu.basketball.dto.response.MatchResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface MatchService {
+
+    MatchResponse getMatch(UUID matchId);
+
+    List<MatchResponse> getMyMatches(Long userId);
+}

--- a/backend/src/main/java/com/pnu/basketball/service/match/MatchService.java
+++ b/backend/src/main/java/com/pnu/basketball/service/match/MatchService.java
@@ -10,4 +10,6 @@ public interface MatchService {
     MatchResponse getMatch(UUID matchId);
 
     List<MatchResponse> getMyMatches(Long userId);
+
+    void completeMatch(UUID matchId, Long userId);
 }

--- a/backend/src/main/java/com/pnu/basketball/service/match/MatchServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/match/MatchServiceImpl.java
@@ -1,10 +1,10 @@
 package com.pnu.basketball.service.match;
 
-import com.pnu.basketball.domain.Match;
+import com.pnu.basketball.domain.*;
 import com.pnu.basketball.dto.response.MatchResponse;
 import com.pnu.basketball.exception.CustomException;
 import com.pnu.basketball.exception.ErrorCode;
-import com.pnu.basketball.repository.MatchRepository;
+import com.pnu.basketball.repository.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +18,11 @@ import java.util.stream.Collectors;
 public class MatchServiceImpl implements MatchService {
 
     private final MatchRepository matchRepository;
+    private final RecruitmentPostRepository recruitmentPostRepository;
+    private final ClubMatchRequestRepository clubMatchRequestRepository;
+    private final ClubMemberRepository clubMemberRepository;
+    private final MatchParticipationRepository participationRepository;
+    private final UserRepository userRepository;
 
     @Override
     @Transactional(readOnly = true)
@@ -33,6 +38,47 @@ public class MatchServiceImpl implements MatchService {
         return matchRepository.findByParticipantUserId(userId).stream()
                 .map(this::toResponse)
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void completeMatch(UUID matchId, Long userId) {
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
+
+        boolean authorized = false;
+
+        if (match.getSourceType() == MatchSourceType.RECRUITMENT && match.getRecruitmentId() != null) {
+            RecruitmentPost post = recruitmentPostRepository.findById(match.getRecruitmentId()).orElse(null);
+            if (post != null && post.isAuthor(userId)) {
+                authorized = true;
+            }
+        } else if (match.getSourceType() == MatchSourceType.CLUB_MATCH && match.getClubMatchRequestId() != null) {
+            ClubMatchRequest request = clubMatchRequestRepository.findById(match.getClubMatchRequestId()).orElse(null);
+            if (request != null) {
+                ClubMember member = clubMemberRepository.findByUserUserId(userId).orElse(null);
+                if (member != null && member.getRole() == ClubRole.PRESIDENT && request.isInvolvedClub(member.getClub().getId())) {
+                    authorized = true;
+                }
+            }
+        }
+
+        User user = userRepository.findById(userId).orElse(null);
+        if (user != null && Boolean.TRUE.equals(user.getIsAdmin())) {
+            authorized = true;
+        }
+
+        if (!authorized) {
+            throw new CustomException(ErrorCode.MATCH_COMPLETE_UNAUTHORIZED);
+        }
+
+        List<MatchParticipation> participations = participationRepository.findByMatchId(matchId);
+        for (MatchParticipation p : participations) {
+            if (p.getStatus() == ParticipationStatus.ATTENDED) {
+                p.getUser().incrementParticipationCount();
+                p.getUser().addExp(match.getSourceType() == MatchSourceType.CLUB_MATCH ? 30 : 10);
+            }
+        }
     }
 
     private MatchResponse toResponse(Match match) {

--- a/backend/src/main/java/com/pnu/basketball/service/match/MatchServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/match/MatchServiceImpl.java
@@ -1,0 +1,50 @@
+package com.pnu.basketball.service.match;
+
+import com.pnu.basketball.domain.Match;
+import com.pnu.basketball.dto.response.MatchResponse;
+import com.pnu.basketball.exception.CustomException;
+import com.pnu.basketball.exception.ErrorCode;
+import com.pnu.basketball.repository.MatchRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MatchServiceImpl implements MatchService {
+
+    private final MatchRepository matchRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public MatchResponse getMatch(UUID matchId) {
+        Match match = matchRepository.findById(matchId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
+        return toResponse(match);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<MatchResponse> getMyMatches(Long userId) {
+        return matchRepository.findByParticipantUserId(userId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    private MatchResponse toResponse(Match match) {
+        return MatchResponse.builder()
+                .id(match.getId())
+                .sourceType(match.getSourceType())
+                .recruitmentId(match.getRecruitmentId())
+                .locationName(match.getLocation().getName())
+                .startAt(match.getStartAt())
+                .endAt(match.getEndAt())
+                .gameFormat(match.getGameFormat())
+                .createdAt(match.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentService.java
+++ b/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentService.java
@@ -1,0 +1,35 @@
+package com.pnu.basketball.service.recruitment;
+
+import com.pnu.basketball.domain.RecruitmentGameFormat;
+import com.pnu.basketball.domain.RecruitmentStatus;
+import com.pnu.basketball.dto.request.RecruitmentApplyRequest;
+import com.pnu.basketball.dto.request.RecruitmentCreateRequest;
+import com.pnu.basketball.dto.response.RecruitmentDetailResponse;
+import com.pnu.basketball.dto.response.RecruitmentListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public interface RecruitmentService {
+
+    RecruitmentDetailResponse create(Long userId, RecruitmentCreateRequest request);
+
+    Page<RecruitmentListResponse> getList(RecruitmentStatus status, UUID locationId,
+                                          RecruitmentGameFormat gameFormat,
+                                          LocalDateTime startFrom, LocalDateTime startTo,
+                                          Pageable pageable);
+
+    RecruitmentDetailResponse getDetail(UUID recruitmentId, Long currentUserId);
+
+    void apply(UUID recruitmentId, Long userId, RecruitmentApplyRequest request);
+
+    void acceptApplication(UUID recruitmentId, UUID applicationId, Long userId);
+
+    void rejectApplication(UUID recruitmentId, UUID applicationId, Long userId);
+
+    RecruitmentDetailResponse confirm(UUID recruitmentId, Long userId);
+
+    void cancel(UUID recruitmentId, Long userId);
+}

--- a/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentServiceImpl.java
@@ -68,7 +68,8 @@ public class RecruitmentServiceImpl implements RecruitmentService {
                                                   RecruitmentGameFormat gameFormat,
                                                   LocalDateTime startFrom, LocalDateTime startTo,
                                                   Pageable pageable) {
-        return recruitmentPostRepository.findAllWithFilters(status, locationId, gameFormat, startFrom, startTo, pageable)
+        var spec = RecruitmentSpecification.withFilters(status, locationId, gameFormat, startFrom, startTo);
+        return recruitmentPostRepository.findAll(spec, pageable)
                 .map(post -> {
                     long acceptedCount = applicationRepository.countByRecruitmentIdAndStatus(
                             post.getId(), ApplicationStatus.ACCEPTED);

--- a/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/recruitment/RecruitmentServiceImpl.java
@@ -1,0 +1,289 @@
+package com.pnu.basketball.service.recruitment;
+
+import com.pnu.basketball.domain.*;
+import com.pnu.basketball.dto.request.RecruitmentApplyRequest;
+import com.pnu.basketball.dto.request.RecruitmentCreateRequest;
+import com.pnu.basketball.dto.response.ApplicationResponse;
+import com.pnu.basketball.dto.response.RecruitmentDetailResponse;
+import com.pnu.basketball.dto.response.RecruitmentListResponse;
+import com.pnu.basketball.exception.CustomException;
+import com.pnu.basketball.exception.ErrorCode;
+import com.pnu.basketball.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class RecruitmentServiceImpl implements RecruitmentService {
+
+    private final RecruitmentPostRepository recruitmentPostRepository;
+    private final RecruitmentApplicationRepository applicationRepository;
+    private final UserRepository userRepository;
+    private final ScheduleLocationRepository locationRepository;
+    private final MatchRepository matchRepository;
+    private final MatchParticipationRepository matchParticipationRepository;
+    private final ScheduleRepository scheduleRepository;
+
+    @Override
+    @Transactional
+    public RecruitmentDetailResponse create(Long userId, RecruitmentCreateRequest request) {
+        User author = findUser(userId);
+
+        if (!request.getStartAt().isBefore(request.getEndAt())) {
+            throw new CustomException(ErrorCode.RECRUITMENT_INVALID_TIME);
+        }
+        if (request.getStartAt().isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.RECRUITMENT_PAST_TIME);
+        }
+
+        ScheduleLocationEntity location = locationRepository.findById(request.getLocationId())
+                .orElseThrow(() -> new CustomException(ErrorCode.SCHEDULE_LOCATION_NOT_FOUND));
+
+        RecruitmentPost post = RecruitmentPost.builder()
+                .author(author)
+                .startAt(request.getStartAt())
+                .endAt(request.getEndAt())
+                .location(location)
+                .baseMembersCount(request.getBaseMembersCount())
+                .neededMembers(request.getNeededMembers())
+                .gameFormat(request.getGameFormat())
+                .deadlineAt(request.getDeadlineAt())
+                .build();
+        recruitmentPostRepository.save(post);
+
+        return toDetailResponse(post, 0L, List.of());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public Page<RecruitmentListResponse> getList(RecruitmentStatus status, UUID locationId,
+                                                  RecruitmentGameFormat gameFormat,
+                                                  LocalDateTime startFrom, LocalDateTime startTo,
+                                                  Pageable pageable) {
+        return recruitmentPostRepository.findAllWithFilters(status, locationId, gameFormat, startFrom, startTo, pageable)
+                .map(post -> {
+                    long acceptedCount = applicationRepository.countByRecruitmentIdAndStatus(
+                            post.getId(), ApplicationStatus.ACCEPTED);
+                    return toListResponse(post, acceptedCount);
+                });
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public RecruitmentDetailResponse getDetail(UUID recruitmentId, Long currentUserId) {
+        RecruitmentPost post = findPost(recruitmentId);
+        long acceptedCount = applicationRepository.countByRecruitmentIdAndStatus(
+                recruitmentId, ApplicationStatus.ACCEPTED);
+        List<RecruitmentApplication> applications = applicationRepository.findByRecruitmentId(recruitmentId);
+
+        return toDetailResponse(post, acceptedCount, applications.stream()
+                .map(this::toApplicationResponse)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    @Transactional
+    public void apply(UUID recruitmentId, Long userId, RecruitmentApplyRequest request) {
+        RecruitmentPost post = findPost(recruitmentId);
+        User applicant = findUser(userId);
+
+        if (post.getStatus() != RecruitmentStatus.OPEN) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_OPEN);
+        }
+        if (post.isAuthor(userId)) {
+            throw new CustomException(ErrorCode.RECRUITMENT_SELF_APPLY);
+        }
+        if (applicationRepository.existsByRecruitmentIdAndApplicantUserId(recruitmentId, userId)) {
+            throw new CustomException(ErrorCode.RECRUITMENT_ALREADY_APPLIED);
+        }
+
+        RecruitmentApplication application = RecruitmentApplication.builder()
+                .recruitment(post)
+                .applicant(applicant)
+                .message(request.getMessage())
+                .build();
+        applicationRepository.save(application);
+    }
+
+    @Override
+    @Transactional
+    public void acceptApplication(UUID recruitmentId, UUID applicationId, Long userId) {
+        RecruitmentPost post = findPost(recruitmentId);
+        validateAuthor(post, userId);
+
+        RecruitmentApplication application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+        if (application.getStatus() != ApplicationStatus.PENDING) {
+            throw new CustomException(ErrorCode.APPLICATION_NOT_PENDING);
+        }
+
+        application.accept();
+    }
+
+    @Override
+    @Transactional
+    public void rejectApplication(UUID recruitmentId, UUID applicationId, Long userId) {
+        RecruitmentPost post = findPost(recruitmentId);
+        validateAuthor(post, userId);
+
+        RecruitmentApplication application = applicationRepository.findById(applicationId)
+                .orElseThrow(() -> new CustomException(ErrorCode.APPLICATION_NOT_FOUND));
+        if (application.getStatus() != ApplicationStatus.PENDING) {
+            throw new CustomException(ErrorCode.APPLICATION_NOT_PENDING);
+        }
+
+        application.reject();
+    }
+
+    @Override
+    @Transactional
+    public RecruitmentDetailResponse confirm(UUID recruitmentId, Long userId) {
+        RecruitmentPost post = findPost(recruitmentId);
+        validateAuthor(post, userId);
+
+        if (post.getStatus() != RecruitmentStatus.OPEN) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_OPEN);
+        }
+        if (matchRepository.findByRecruitmentId(recruitmentId).isPresent()) {
+            throw new CustomException(ErrorCode.MATCH_ALREADY_EXISTS);
+        }
+
+        post.confirm();
+
+        Match match = Match.builder()
+                .sourceType(MatchSourceType.RECRUITMENT)
+                .recruitmentId(recruitmentId)
+                .location(post.getLocation())
+                .startAt(post.getStartAt())
+                .endAt(post.getEndAt())
+                .gameFormat(post.getGameFormat())
+                .build();
+        matchRepository.save(match);
+
+        Schedule schedule = Schedule.builder()
+                .location(post.getLocation())
+                .scheduleDate(post.getStartAt().toLocalDate())
+                .startTime(post.getStartAt().toLocalTime())
+                .endTime(post.getEndAt().toLocalTime())
+                .status(ScheduleStatus.SCHEDULED)
+                .scheduleType("MATCH")
+                .title("게스트 모집 경기")
+                .matchId(match.getId())
+                .build();
+        scheduleRepository.save(schedule);
+
+        List<RecruitmentApplication> accepted = applicationRepository
+                .findByRecruitmentIdAndStatus(recruitmentId, ApplicationStatus.ACCEPTED);
+
+        MatchParticipation authorParticipation = MatchParticipation.builder()
+                .match(match)
+                .user(post.getAuthor())
+                .status(ParticipationStatus.ATTENDED)
+                .build();
+        matchParticipationRepository.save(authorParticipation);
+
+        for (RecruitmentApplication app : accepted) {
+            MatchParticipation participation = MatchParticipation.builder()
+                    .match(match)
+                    .user(app.getApplicant())
+                    .status(ParticipationStatus.ATTENDED)
+                    .build();
+            matchParticipationRepository.save(participation);
+        }
+
+        long acceptedCount = accepted.size();
+        List<RecruitmentApplication> allApps = applicationRepository.findByRecruitmentId(recruitmentId);
+
+        return toDetailResponse(post, acceptedCount, allApps.stream()
+                .map(this::toApplicationResponse)
+                .collect(Collectors.toList()));
+    }
+
+    @Override
+    @Transactional
+    public void cancel(UUID recruitmentId, Long userId) {
+        RecruitmentPost post = findPost(recruitmentId);
+        validateAuthor(post, userId);
+        post.cancel();
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    private RecruitmentPost findPost(UUID id) {
+        return recruitmentPostRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.RECRUITMENT_NOT_FOUND));
+    }
+
+    private void validateAuthor(RecruitmentPost post, Long userId) {
+        if (!post.isAuthor(userId)) {
+            throw new CustomException(ErrorCode.RECRUITMENT_NOT_AUTHOR);
+        }
+    }
+
+    private RecruitmentListResponse toListResponse(RecruitmentPost post, long acceptedCount) {
+        return RecruitmentListResponse.builder()
+                .id(post.getId())
+                .authorNickname(post.getAuthor().getNickname())
+                .startAt(post.getStartAt())
+                .endAt(post.getEndAt())
+                .locationName(post.getLocation().getName())
+                .baseMembersCount(post.getBaseMembersCount())
+                .neededMembers(post.getNeededMembers())
+                .acceptedCount(acceptedCount)
+                .gameFormat(post.getGameFormat())
+                .status(post.getStatus())
+                .deadlineAt(post.getDeadlineAt())
+                .createdAt(post.getCreatedAt())
+                .isFull(acceptedCount >= post.getNeededMembers())
+                .build();
+    }
+
+    private RecruitmentDetailResponse toDetailResponse(RecruitmentPost post, long acceptedCount,
+                                                        List<ApplicationResponse> applications) {
+        return RecruitmentDetailResponse.builder()
+                .id(post.getId())
+                .authorId(post.getAuthor().getUserId())
+                .authorNickname(post.getAuthor().getNickname())
+                .startAt(post.getStartAt())
+                .endAt(post.getEndAt())
+                .locationId(post.getLocation().getId())
+                .locationName(post.getLocation().getName())
+                .baseMembersCount(post.getBaseMembersCount())
+                .neededMembers(post.getNeededMembers())
+                .acceptedCount(acceptedCount)
+                .gameFormat(post.getGameFormat())
+                .status(post.getStatus())
+                .deadlineAt(post.getDeadlineAt())
+                .createdAt(post.getCreatedAt())
+                .isFull(acceptedCount >= post.getNeededMembers())
+                .applications(applications)
+                .build();
+    }
+
+    private ApplicationResponse toApplicationResponse(RecruitmentApplication app) {
+        User applicant = app.getApplicant();
+        return ApplicationResponse.builder()
+                .applicationId(app.getId())
+                .applicantId(applicant.getUserId())
+                .applicantNickname(applicant.getNickname())
+                .applicantPosition(applicant.getPosition())
+                .applicantExp(applicant.getExp())
+                .applicantNoShowCount(applicant.getNoShowCount())
+                .applicantParticipationCount(applicant.getParticipationCount())
+                .status(app.getStatus())
+                .message(app.getMessage())
+                .createdAt(app.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/service/review/ReviewService.java
+++ b/backend/src/main/java/com/pnu/basketball/service/review/ReviewService.java
@@ -1,0 +1,21 @@
+package com.pnu.basketball.service.review;
+
+import com.pnu.basketball.dto.request.ReviewSubmitRequest;
+import com.pnu.basketball.dto.response.NoShowReportResponse;
+import com.pnu.basketball.dto.response.ReviewFormResponse;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ReviewService {
+
+    ReviewFormResponse getReviewForm(UUID matchId, Long userId);
+
+    void submitReview(UUID matchId, Long userId, ReviewSubmitRequest request);
+
+    List<NoShowReportResponse> getPendingNoShowReports();
+
+    void confirmNoShow(UUID reportId);
+
+    void rejectNoShow(UUID reportId);
+}

--- a/backend/src/main/java/com/pnu/basketball/service/review/ReviewServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/review/ReviewServiceImpl.java
@@ -1,0 +1,155 @@
+package com.pnu.basketball.service.review;
+
+import com.pnu.basketball.domain.*;
+import com.pnu.basketball.dto.request.ReviewSubmitRequest;
+import com.pnu.basketball.dto.response.NoShowReportResponse;
+import com.pnu.basketball.dto.response.ReviewFormResponse;
+import com.pnu.basketball.exception.CustomException;
+import com.pnu.basketball.exception.ErrorCode;
+import com.pnu.basketball.repository.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private static final int REVIEW_DEADLINE_HOURS = 24;
+
+    private final MatchRepository matchRepository;
+    private final MatchParticipationRepository participationRepository;
+    private final ParticipationReviewRepository reviewRepository;
+    private final NoShowReportRepository noShowReportRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public ReviewFormResponse getReviewForm(UUID matchId, Long userId) {
+        Match match = findMatch(matchId);
+        validateParticipant(matchId, userId);
+
+        boolean alreadySubmitted = !reviewRepository.findByMatchId(matchId).stream()
+                .filter(r -> r.getReviewer().getUserId().equals(userId))
+                .toList().isEmpty();
+
+        List<MatchParticipation> participations = participationRepository.findByMatchId(matchId);
+        List<ReviewFormResponse.ParticipantInfo> participants = participations.stream()
+                .filter(p -> !p.getUser().getUserId().equals(userId))
+                .map(p -> ReviewFormResponse.ParticipantInfo.builder()
+                        .userId(p.getUser().getUserId())
+                        .nickname(p.getUser().getNickname())
+                        .position(p.getUser().getPosition())
+                        .exp(p.getUser().getExp())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ReviewFormResponse.builder()
+                .matchId(matchId)
+                .startAt(match.getStartAt())
+                .endAt(match.getEndAt())
+                .locationName(match.getLocation().getName())
+                .alreadySubmitted(alreadySubmitted)
+                .participants(participants)
+                .build();
+    }
+
+    @Override
+    @Transactional
+    public void submitReview(UUID matchId, Long userId, ReviewSubmitRequest request) {
+        Match match = findMatch(matchId);
+        validateParticipant(matchId, userId);
+
+        if (match.getEndAt().plusHours(REVIEW_DEADLINE_HOURS).isBefore(LocalDateTime.now())) {
+            throw new CustomException(ErrorCode.REVIEW_PERIOD_EXPIRED);
+        }
+
+        User reviewer = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if (request.getThumbsUpUserIds() != null) {
+            for (Long revieweeId : request.getThumbsUpUserIds()) {
+                if (revieweeId.equals(userId)) continue;
+                if (reviewRepository.existsByMatchIdAndReviewerUserIdAndRevieweeUserId(matchId, userId, revieweeId)) {
+                    continue;
+                }
+                User reviewee = userRepository.findById(revieweeId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                reviewRepository.save(ParticipationReview.builder()
+                        .match(match)
+                        .reviewer(reviewer)
+                        .reviewee(reviewee)
+                        .build());
+            }
+        }
+
+        if (request.getNoShowUserIds() != null) {
+            for (Long reportedId : request.getNoShowUserIds()) {
+                if (reportedId.equals(userId)) continue;
+                if (noShowReportRepository.existsByMatchIdAndReporterUserIdAndReportedUserUserId(matchId, userId, reportedId)) {
+                    continue;
+                }
+                User reportedUser = userRepository.findById(reportedId)
+                        .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+                noShowReportRepository.save(NoShowReport.builder()
+                        .match(match)
+                        .reporter(reviewer)
+                        .reportedUser(reportedUser)
+                        .build());
+            }
+        }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<NoShowReportResponse> getPendingNoShowReports() {
+        return noShowReportRepository.findByStatus(NoShowReportStatus.PENDING).stream()
+                .map(this::toNoShowResponse)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public void confirmNoShow(UUID reportId) {
+        NoShowReport report = noShowReportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_SHOW_REPORT_NOT_FOUND));
+        report.confirm();
+        report.getReportedUser().incrementNoShowCount();
+    }
+
+    @Override
+    @Transactional
+    public void rejectNoShow(UUID reportId) {
+        NoShowReport report = noShowReportRepository.findById(reportId)
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_SHOW_REPORT_NOT_FOUND));
+        report.reject();
+    }
+
+    private Match findMatch(UUID matchId) {
+        return matchRepository.findById(matchId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MATCH_NOT_FOUND));
+    }
+
+    private void validateParticipant(UUID matchId, Long userId) {
+        if (!participationRepository.existsByMatchIdAndUserUserId(matchId, userId)) {
+            throw new CustomException(ErrorCode.REVIEW_NOT_PARTICIPANT);
+        }
+    }
+
+    private NoShowReportResponse toNoShowResponse(NoShowReport report) {
+        return NoShowReportResponse.builder()
+                .id(report.getId())
+                .matchId(report.getMatch().getId())
+                .reporterNickname(report.getReporter().getNickname())
+                .reportedUserId(report.getReportedUser().getUserId())
+                .reportedUserNickname(report.getReportedUser().getNickname())
+                .status(report.getStatus())
+                .createdAt(report.getCreatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pnu/basketball/service/user/UserServiceImpl.java
+++ b/backend/src/main/java/com/pnu/basketball/service/user/UserServiceImpl.java
@@ -37,11 +37,19 @@ public class UserServiceImpl implements UserService {
     public UserResponse updateProfile(Long userId, UpdateProfileRequest request) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
-        
+
+        if (request.getNickname() != null && !request.getNickname().isBlank()) {
+            if (userRepository.existsByNicknameAndUserIdNot(request.getNickname(), userId)) {
+                throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+            }
+        }
+
         user.updateProfile(
                 request.getRealName(),
                 request.getPhoneNumber(),
-                request.getProfileImageUrl()
+                request.getProfileImageUrl(),
+                request.getNickname(),
+                request.getPosition()
         );
         
         return toUserResponse(user);
@@ -59,12 +67,20 @@ public class UserServiceImpl implements UserService {
             }
         }
 
+        if (request.getNickname() != null && !request.getNickname().isBlank()) {
+            if (userRepository.existsByNicknameAndUserIdNot(request.getNickname(), userId)) {
+                throw new CustomException(ErrorCode.NICKNAME_ALREADY_EXISTS);
+            }
+        }
+
         user.completeProfile(
                 request.getRealName(),
                 request.getDateOfBirth(),
                 request.getIsPnuStudent(),
                 request.getIsPnuStudent() != null && request.getIsPnuStudent() ? request.getDepartment() : null,
-                request.getIsPnuStudent() != null && request.getIsPnuStudent() ? request.getStudentId() : null
+                request.getIsPnuStudent() != null && request.getIsPnuStudent() ? request.getStudentId() : null,
+                request.getNickname(),
+                request.getPosition()
         );
         userRepository.save(user);
 
@@ -84,6 +100,11 @@ public class UserServiceImpl implements UserService {
                 .department(user.getDepartment())
                 .studentId(user.getStudentId())
                 .createdAt(user.getCreatedAt())
+                .nickname(user.getNickname())
+                .position(user.getPosition())
+                .exp(user.getExp())
+                .noShowCount(user.getNoShowCount())
+                .participationCount(user.getParticipationCount())
                 .build();
     }
     

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -1,0 +1,8 @@
+# local 프로파일: Redis 없이 인메모리 토큰 저장
+# Redis 자동설정 비활성화 → Spring Data Redis 리포지토리 스캔 로그 제거
+
+spring:
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
+      - org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -5,6 +5,9 @@
 # 기본값: local 프로파일 (Redis 없이 인메모리 토큰 저장)
 # 운영 배포 시: --spring.profiles.active=prod 또는 SPRING_PROFILES_ACTIVE=prod
 
+app:
+  token-storage: memory   # Redis 없이 로컬 개발 시 memory 사용. prod에서는 redis로 변경
+
 spring:
   profiles:
     active: local

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -12,6 +12,9 @@ spring:
   profiles:
     active: local
     include: secret
+  # application-secret.yml 명시적 로드 (working directory에 따라 ./config/ 또는 ./ 경로 사용)
+  config:
+    import: optional:file:./config/application-secret.yml,optional:file:./application-secret.yml
 
 # JWT 토큰 만료 시간 (민감하지 않은 값 - application-secret.yml에 jwt.secret 필요)
 jwt:

--- a/backend/src/main/resources/static/admin/css/admin.css
+++ b/backend/src/main/resources/static/admin/css/admin.css
@@ -665,3 +665,60 @@ body {
         width: 100%;
     }
 }
+
+/* 사이드바 구분선 */
+.nav-divider {
+    height: 1px;
+    background: rgba(255, 255, 255, 0.2);
+    margin: 8px 20px 16px;
+}
+
+/* 테이블 내 소형 버튼 */
+.btn-sm {
+    padding: 4px 10px;
+    font-size: 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    background: #667eea;
+    color: white;
+    transition: background 0.2s;
+}
+
+.btn-sm:hover {
+    background: #5a6fd6;
+}
+
+.btn-danger-sm {
+    background: #e53e3e;
+}
+
+.btn-danger-sm:hover {
+    background: #c53030;
+}
+
+/* 상태 배지: 활성 (파란색 계열) */
+.status-badge.status-active {
+    background: #ebf8ff;
+    color: #2b6cb0;
+}
+
+/* 상세 모달 그리드 */
+.detail-grid {
+    display: grid;
+    gap: 12px;
+}
+
+.detail-row {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 8px 0;
+    border-bottom: 1px solid #edf2f7;
+}
+
+.detail-row strong {
+    min-width: 80px;
+    color: #4a5568;
+    font-size: 13px;
+}

--- a/backend/src/main/resources/static/admin/index.html
+++ b/backend/src/main/resources/static/admin/index.html
@@ -57,6 +57,19 @@
                     <span class="tab-icon">📅</span>
                     <span class="tab-text">일정 관리</span>
                 </button>
+                <div class="nav-divider"></div>
+                <button type="button" class="nav-tab" data-tab="recruitments">
+                    <span class="tab-icon">🏟️</span>
+                    <span class="tab-text">모집글 관리</span>
+                </button>
+                <button type="button" class="nav-tab" data-tab="noShowReports">
+                    <span class="tab-icon">🚫</span>
+                    <span class="tab-text">노쇼 신고</span>
+                </button>
+                <button type="button" class="nav-tab" data-tab="clubMatchAdmin">
+                    <span class="tab-icon">⚔️</span>
+                    <span class="tab-text">친선전 관리</span>
+                </button>
             </nav>
             <button type="button" class="logout-btn" id="logout-btn">로그아웃</button>
         </aside>
@@ -269,7 +282,143 @@
                 </div>
             </div>
 
+            <!-- 모집글 관리 -->
+            <div id="tab-recruitments" class="tab-content">
+                <div class="content-header">
+                    <h1>모집글 관리</h1>
+                    <div class="header-info">
+                        <span class="total-count">총 <strong id="recruitments-total">0</strong>건</span>
+                    </div>
+                </div>
+                <div class="filter-section">
+                    <div class="filter-group">
+                        <div class="filter-item">
+                            <label>상태</label>
+                            <select id="filter-recruitment-status" class="filter-select">
+                                <option value="">전체</option>
+                                <option value="OPEN">모집중</option>
+                                <option value="CONFIRMED">확정</option>
+                                <option value="CLOSED">마감</option>
+                                <option value="CANCELLED">취소</option>
+                            </select>
+                        </div>
+                        <div class="filter-item">
+                            <label>경기형태</label>
+                            <select id="filter-recruitment-format" class="filter-select">
+                                <option value="">전체</option>
+                                <option value="THREE_VS_THREE">3:3</option>
+                                <option value="FOUR_VS_FOUR">4:4</option>
+                                <option value="FIVE_VS_FIVE">5:5</option>
+                                <option value="FLEXIBLE">자유</option>
+                            </select>
+                        </div>
+                        <div class="filter-item">
+                            <button type="button" class="search-btn" id="btn-search-recruitments">조회</button>
+                            <button type="button" class="reset-btn" id="btn-reset-recruitments">초기화</button>
+                        </div>
+                    </div>
+                </div>
+                <div class="table-section">
+                    <div class="table-wrapper">
+                        <table class="member-table">
+                            <thead>
+                                <tr>
+                                    <th>작성자</th>
+                                    <th>장소</th>
+                                    <th>시간</th>
+                                    <th>형태</th>
+                                    <th>인원</th>
+                                    <th>상태</th>
+                                    <th>생성일</th>
+                                    <th>액션</th>
+                                </tr>
+                            </thead>
+                            <tbody id="recruitments-tbody">
+                                <tr><td colspan="8" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="pagination" id="recruitments-pagination"></div>
+                </div>
+            </div>
+
+            <!-- 노쇼 신고 관리 -->
+            <div id="tab-noShowReports" class="tab-content">
+                <div class="content-header">
+                    <h1>노쇼 신고 관리</h1>
+                    <div class="header-info">
+                        <span class="total-count">대기중 <strong id="noshow-total">0</strong>건</span>
+                    </div>
+                </div>
+                <div class="table-section">
+                    <div class="table-wrapper">
+                        <table class="member-table">
+                            <thead>
+                                <tr>
+                                    <th>경기 ID</th>
+                                    <th>신고자</th>
+                                    <th>피신고자</th>
+                                    <th>상태</th>
+                                    <th>신고일</th>
+                                    <th>액션</th>
+                                </tr>
+                            </thead>
+                            <tbody id="noshow-tbody">
+                                <tr><td colspan="6" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 친선전 관리 -->
+            <div id="tab-clubMatchAdmin" class="tab-content">
+                <div class="content-header">
+                    <h1>친선전 결과 관리</h1>
+                    <div class="header-info">
+                        <span class="total-count">승인 대기 <strong id="clubmatch-pending-total">0</strong>건</span>
+                    </div>
+                </div>
+                <div class="table-section">
+                    <div class="table-wrapper">
+                        <table class="member-table">
+                            <thead>
+                                <tr>
+                                    <th>홈팀</th>
+                                    <th>원정팀</th>
+                                    <th>장소</th>
+                                    <th>시간</th>
+                                    <th>홈 점수</th>
+                                    <th>원정 점수</th>
+                                    <th>상태</th>
+                                    <th>액션</th>
+                                </tr>
+                            </thead>
+                            <tbody id="clubmatch-tbody">
+                                <tr><td colspan="8" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+
         </main>
+    </div>
+
+    <!-- 모집글 상세 모달 -->
+    <div id="modal-recruitment-detail" class="modal">
+        <div class="modal-content modal-wide">
+            <div class="modal-header">
+                <h3>모집글 상세</h3>
+                <button type="button" class="modal-close" data-close="modal-recruitment-detail">&times;</button>
+            </div>
+            <div class="modal-body" id="modal-recruitment-detail-body">
+                <p>로딩 중...</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-cancel" data-close="modal-recruitment-detail">닫기</button>
+            </div>
+        </div>
     </div>
 
     <!-- 유저 상세 모달 -->
@@ -497,6 +646,9 @@
     <script src="js/posts.js"></script>
     <script src="js/schedule-locations.js"></script>
     <script src="js/schedules.js"></script>
+    <script src="js/recruitments.js"></script>
+    <script src="js/no-show-reports.js"></script>
+    <script src="js/club-match-admin.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', function () {
             if (Admin.isLoggedIn()) {

--- a/backend/src/main/resources/static/admin/js/club-match-admin.js
+++ b/backend/src/main/resources/static/admin/js/club-match-admin.js
@@ -1,0 +1,74 @@
+/**
+ * 친선전 결과 관리
+ */
+function loadClubMatchAdmin() {
+    var tbody = document.getElementById('clubmatch-tbody');
+    tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>';
+
+    Admin.apiRequest('/club-matches/requests/admin/pending')
+        .then(function (res) {
+            var requests = res.data || res;
+            if (!Array.isArray(requests)) requests = [];
+
+            document.getElementById('clubmatch-pending-total').textContent = requests.length;
+
+            if (requests.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>승인 대기 중인 친선전이 없습니다.</p></td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = requests.map(function (r) {
+                var startAt = formatDateTime(r.startAt);
+                var statusBadge = clubMatchStatusBadge(r.status);
+
+                return '<tr>'
+                    + '<td><strong>' + escapeHtml(r.homeClubName || '-') + '</strong></td>'
+                    + '<td>' + escapeHtml(r.awayClubName || '-') + '</td>'
+                    + '<td>' + escapeHtml(r.locationName || '-') + '</td>'
+                    + '<td>' + startAt + '</td>'
+                    + '<td>' + (r.homeScore != null ? r.homeScore : '-') + '</td>'
+                    + '<td>' + (r.awayScore != null ? r.awayScore : '-') + '</td>'
+                    + '<td>' + statusBadge + '</td>'
+                    + '<td><button class="btn-sm btn-confirm-clubmatch" data-id="' + r.id + '">확정</button></td>'
+                    + '</tr>';
+            }).join('');
+
+            bindClubMatchAdminEvents();
+        })
+        .catch(function (err) {
+            tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>오류: ' + escapeHtml(err.message) + '</p></td></tr>';
+        });
+}
+
+function bindClubMatchAdminEvents() {
+    document.querySelectorAll('.btn-confirm-clubmatch').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = this.getAttribute('data-id');
+            if (!confirm('이 친선전 결과를 최종 확정하시겠습니까?\n동아리 전적에 반영됩니다.')) return;
+
+            Admin.apiRequest('/club-matches/requests/admin/' + id + '/confirm', { method: 'POST' })
+                .then(function () {
+                    alert('친선전 결과가 확정되었습니다.');
+                    loadClubMatchAdmin();
+                })
+                .catch(function (err) {
+                    alert('실패: ' + err.message);
+                });
+        });
+    });
+}
+
+function clubMatchStatusBadge(status) {
+    var cls = 'status-badge ';
+    var label;
+    switch (status) {
+        case 'GATHERING': cls += 'status-pending'; label = '모집중'; break;
+        case 'READY': cls += 'status-pending'; label = '준비완료'; break;
+        case 'MATCHED': cls += 'status-active'; label = '매칭완료'; break;
+        case 'CONFIRMED': cls += 'status-approved'; label = '확정'; break;
+        case 'DONE': cls += 'status-approved'; label = '완료'; break;
+        case 'CANCELLED': cls += 'status-rejected'; label = '취소'; break;
+        default: cls += 'status-pending'; label = status || '-';
+    }
+    return '<span class="' + cls + '">' + label + '</span>';
+}

--- a/backend/src/main/resources/static/admin/js/no-show-reports.js
+++ b/backend/src/main/resources/static/admin/js/no-show-reports.js
@@ -1,0 +1,94 @@
+/**
+ * 노쇼 신고 관리
+ */
+function loadNoShowReports() {
+    var tbody = document.getElementById('noshow-tbody');
+    tbody.innerHTML = '<tr><td colspan="6" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>';
+
+    Admin.apiRequest('/matches/admin/no-show-reports')
+        .then(function (res) {
+            var reports = res.data || res;
+            if (!Array.isArray(reports)) reports = [];
+
+            document.getElementById('noshow-total').textContent = reports.length;
+
+            if (reports.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="6" class="empty-state"><p>처리 대기 중인 노쇼 신고가 없습니다.</p></td></tr>';
+                return;
+            }
+
+            tbody.innerHTML = reports.map(function (r) {
+                var statusBadge = noShowStatusBadge(r.status);
+                var createdAt = formatDateTime(r.createdAt);
+                var matchIdShort = r.matchId ? String(r.matchId).substring(0, 8) + '...' : '-';
+
+                var actions = '';
+                if (r.status === 'PENDING') {
+                    actions = '<button class="btn-sm btn-confirm-noshow" data-id="' + r.id + '">확정</button>'
+                        + ' <button class="btn-sm btn-danger-sm btn-reject-noshow" data-id="' + r.id + '">반려</button>';
+                } else {
+                    actions = '<span style="color:#718096; font-size:12px;">처리 완료</span>';
+                }
+
+                return '<tr>'
+                    + '<td title="' + (r.matchId || '') + '">' + matchIdShort + '</td>'
+                    + '<td>' + escapeHtml(r.reporterNickname || '-') + '</td>'
+                    + '<td>' + escapeHtml(r.reportedUserNickname || '-') + '</td>'
+                    + '<td>' + statusBadge + '</td>'
+                    + '<td>' + createdAt + '</td>'
+                    + '<td>' + actions + '</td>'
+                    + '</tr>';
+            }).join('');
+
+            bindNoShowEvents();
+        })
+        .catch(function (err) {
+            tbody.innerHTML = '<tr><td colspan="6" class="empty-state"><p>오류: ' + escapeHtml(err.message) + '</p></td></tr>';
+        });
+}
+
+function bindNoShowEvents() {
+    document.querySelectorAll('.btn-confirm-noshow').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = this.getAttribute('data-id');
+            if (!confirm('이 노쇼 신고를 확정하시겠습니까?\n해당 유저의 노쇼 횟수가 증가합니다.')) return;
+
+            Admin.apiRequest('/matches/admin/no-show-reports/' + id + '/confirm', { method: 'POST' })
+                .then(function () {
+                    alert('노쇼가 확정되었습니다.');
+                    loadNoShowReports();
+                })
+                .catch(function (err) {
+                    alert('실패: ' + err.message);
+                });
+        });
+    });
+
+    document.querySelectorAll('.btn-reject-noshow').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            var id = this.getAttribute('data-id');
+            if (!confirm('이 노쇼 신고를 반려하시겠습니까?')) return;
+
+            Admin.apiRequest('/matches/admin/no-show-reports/' + id + '/reject', { method: 'POST' })
+                .then(function () {
+                    alert('노쇼 신고가 반려되었습니다.');
+                    loadNoShowReports();
+                })
+                .catch(function (err) {
+                    alert('실패: ' + err.message);
+                });
+        });
+    });
+}
+
+function noShowStatusBadge(status) {
+    var cls = 'status-badge ';
+    var label;
+    switch (status) {
+        case 'PENDING': cls += 'status-pending'; label = '대기'; break;
+        case 'CONFIRMED': cls += 'status-rejected'; label = '확정'; break;
+        case 'REJECTED': cls += 'status-approved'; label = '반려'; break;
+        default: cls += 'status-pending'; label = status || '-';
+    }
+    return '<span class="' + cls + '">' + label + '</span>';
+}

--- a/backend/src/main/resources/static/admin/js/recruitments.js
+++ b/backend/src/main/resources/static/admin/js/recruitments.js
@@ -1,0 +1,256 @@
+/**
+ * 모집글 관리
+ */
+const RecruitmentsState = {
+    page: 0,
+    size: 20,
+    status: '',
+    gameFormat: '',
+};
+
+function loadRecruitments() {
+    const tbody = document.getElementById('recruitments-tbody');
+    tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>데이터를 불러오는 중...</p></td></tr>';
+
+    const params = new URLSearchParams({
+        page: RecruitmentsState.page,
+        size: RecruitmentsState.size,
+    });
+    if (RecruitmentsState.status) params.append('status', RecruitmentsState.status);
+    if (RecruitmentsState.gameFormat) params.append('gameFormat', RecruitmentsState.gameFormat);
+
+    Admin.apiRequest(`/recruitments?${params.toString()}`)
+        .then(function (res) {
+            const data = res.data || res;
+            const content = data.content || [];
+            const totalElements = data.totalElements || 0;
+
+            document.getElementById('recruitments-total').textContent = totalElements;
+
+            if (content.length === 0) {
+                tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>등록된 모집글이 없습니다.</p></td></tr>';
+                document.getElementById('recruitments-pagination').innerHTML = '';
+                return;
+            }
+
+            tbody.innerHTML = content.map(function (r) {
+                const startAt = formatDateTime(r.startAt);
+                const createdAt = formatDate(r.createdAt);
+                const format = formatGameFormat(r.gameFormat);
+                const statusBadge = recruitmentStatusBadge(r.status);
+                const progress = (r.baseMembersCount || 0) + '+'
+                    + (r.acceptedCount || 0) + '/'
+                    + ((r.baseMembersCount || 0) + (r.neededMembers || 0));
+
+                return '<tr>'
+                    + '<td>' + escapeHtml(r.authorNickname || '-') + '</td>'
+                    + '<td>' + escapeHtml(r.locationName || '-') + '</td>'
+                    + '<td>' + startAt + '</td>'
+                    + '<td>' + format + '</td>'
+                    + '<td>' + progress + '</td>'
+                    + '<td>' + statusBadge + '</td>'
+                    + '<td>' + createdAt + '</td>'
+                    + '<td><button class="btn-sm btn-view-recruitment" data-id="' + r.id + '">상세</button></td>'
+                    + '</tr>';
+            }).join('');
+
+            renderRecruitmentsPagination(data);
+            bindRecruitmentEvents();
+        })
+        .catch(function (err) {
+            tbody.innerHTML = '<tr><td colspan="8" class="empty-state"><p>오류: ' + escapeHtml(err.message) + '</p></td></tr>';
+        });
+}
+
+function renderRecruitmentsPagination(data) {
+    const container = document.getElementById('recruitments-pagination');
+    const totalPages = data.totalPages || 1;
+    const current = data.number || 0;
+
+    if (totalPages <= 1) {
+        container.innerHTML = '';
+        return;
+    }
+
+    let html = '';
+    if (current > 0) {
+        html += '<button class="page-btn" data-page="' + (current - 1) + '">이전</button>';
+    }
+
+    const start = Math.max(0, current - 2);
+    const end = Math.min(totalPages, start + 5);
+    for (let i = start; i < end; i++) {
+        html += '<button class="page-btn' + (i === current ? ' active' : '') + '" data-page="' + i + '">' + (i + 1) + '</button>';
+    }
+
+    if (current < totalPages - 1) {
+        html += '<button class="page-btn" data-page="' + (current + 1) + '">다음</button>';
+    }
+
+    container.innerHTML = html;
+    container.querySelectorAll('.page-btn').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            RecruitmentsState.page = parseInt(this.getAttribute('data-page'));
+            loadRecruitments();
+        });
+    });
+}
+
+function bindRecruitmentEvents() {
+    document.querySelectorAll('.btn-view-recruitment').forEach(function (btn) {
+        btn.addEventListener('click', function () {
+            openRecruitmentDetail(this.getAttribute('data-id'));
+        });
+    });
+}
+
+function openRecruitmentDetail(id) {
+    const body = document.getElementById('modal-recruitment-detail-body');
+    body.innerHTML = '<p>로딩 중...</p>';
+    document.getElementById('modal-recruitment-detail').classList.add('show');
+
+    Admin.apiRequest('/recruitments/' + id)
+        .then(function (res) {
+            const r = res.data || res;
+            const startAt = formatDateTime(r.startAt);
+            const endAt = formatDateTime(r.endAt);
+            const format = formatGameFormat(r.gameFormat);
+            const statusBadge = recruitmentStatusBadge(r.status);
+            const deadlineAt = r.deadlineAt ? formatDateTime(r.deadlineAt) : '-';
+            const progress = (r.baseMembersCount || 0) + '+' + (r.acceptedCount || 0)
+                + ' / ' + ((r.baseMembersCount || 0) + (r.neededMembers || 0)) + '명';
+
+            let html = '<div class="detail-grid">'
+                + '<div class="detail-row"><strong>상태</strong>' + statusBadge + '</div>'
+                + '<div class="detail-row"><strong>작성자</strong>' + escapeHtml(r.authorNickname || '-') + '</div>'
+                + '<div class="detail-row"><strong>장소</strong>' + escapeHtml(r.locationName || '-') + '</div>'
+                + '<div class="detail-row"><strong>시간</strong>' + startAt + ' ~ ' + endAt + '</div>'
+                + '<div class="detail-row"><strong>경기형태</strong>' + format + '</div>'
+                + '<div class="detail-row"><strong>인원</strong>' + progress + '</div>'
+                + '<div class="detail-row"><strong>마감시각</strong>' + deadlineAt + '</div>'
+                + '</div>';
+
+            var apps = r.applications || [];
+            if (apps.length > 0) {
+                html += '<h4 style="margin-top:20px; margin-bottom:10px;">신청 목록 (' + apps.length + ')</h4>';
+                html += '<table class="member-table"><thead><tr>'
+                    + '<th>닉네임</th><th>포지션</th><th>EXP</th><th>노쇼</th><th>상태</th><th>메시지</th>'
+                    + '</tr></thead><tbody>';
+                apps.forEach(function (a) {
+                    var appStatus = applicationStatusBadge(a.status);
+                    html += '<tr>'
+                        + '<td>' + escapeHtml(a.applicantNickname || '-') + '</td>'
+                        + '<td>' + formatPosition(a.applicantPosition) + '</td>'
+                        + '<td>' + (a.applicantExp || 0) + '</td>'
+                        + '<td>' + (a.applicantNoShowCount || 0) + '</td>'
+                        + '<td>' + appStatus + '</td>'
+                        + '<td>' + escapeHtml(a.message || '-') + '</td>'
+                        + '</tr>';
+                });
+                html += '</tbody></table>';
+            }
+
+            body.innerHTML = html;
+        })
+        .catch(function (err) {
+            body.innerHTML = '<p style="color: #991b1b;">오류: ' + escapeHtml(err.message) + '</p>';
+        });
+}
+
+// 필터 & 이벤트 바인딩
+document.addEventListener('DOMContentLoaded', function () {
+    var btnSearch = document.getElementById('btn-search-recruitments');
+    if (btnSearch) {
+        btnSearch.addEventListener('click', function () {
+            RecruitmentsState.status = document.getElementById('filter-recruitment-status').value;
+            RecruitmentsState.gameFormat = document.getElementById('filter-recruitment-format').value;
+            RecruitmentsState.page = 0;
+            loadRecruitments();
+        });
+    }
+
+    var btnReset = document.getElementById('btn-reset-recruitments');
+    if (btnReset) {
+        btnReset.addEventListener('click', function () {
+            document.getElementById('filter-recruitment-status').value = '';
+            document.getElementById('filter-recruitment-format').value = '';
+            RecruitmentsState.status = '';
+            RecruitmentsState.gameFormat = '';
+            RecruitmentsState.page = 0;
+            loadRecruitments();
+        });
+    }
+});
+
+// ── 유틸리티 함수 ──
+
+function formatDateTime(isoStr) {
+    if (!isoStr) return '-';
+    var d = new Date(isoStr);
+    return d.getFullYear() + '-'
+        + String(d.getMonth() + 1).padStart(2, '0') + '-'
+        + String(d.getDate()).padStart(2, '0') + ' '
+        + String(d.getHours()).padStart(2, '0') + ':'
+        + String(d.getMinutes()).padStart(2, '0');
+}
+
+function formatDate(isoStr) {
+    if (!isoStr) return '-';
+    var d = new Date(isoStr);
+    return d.getFullYear() + '-'
+        + String(d.getMonth() + 1).padStart(2, '0') + '-'
+        + String(d.getDate()).padStart(2, '0');
+}
+
+function formatGameFormat(val) {
+    switch (val) {
+        case 'THREE_VS_THREE': return '3:3';
+        case 'FOUR_VS_FOUR': return '4:4';
+        case 'FIVE_VS_FIVE': return '5:5';
+        case 'FLEXIBLE': return '자유';
+        default: return val || '-';
+    }
+}
+
+function formatPosition(val) {
+    switch (val) {
+        case 'GUARD': return '가드';
+        case 'FORWARD': return '포워드';
+        case 'CENTER': return '센터';
+        default: return val || '-';
+    }
+}
+
+function recruitmentStatusBadge(status) {
+    var cls = 'status-badge ';
+    var label;
+    switch (status) {
+        case 'OPEN': cls += 'status-approved'; label = '모집중'; break;
+        case 'CONFIRMED': cls += 'status-active'; label = '확정'; break;
+        case 'CLOSED': cls += 'status-pending'; label = '마감'; break;
+        case 'CANCELLED': cls += 'status-rejected'; label = '취소'; break;
+        default: cls += 'status-pending'; label = status || '-';
+    }
+    return '<span class="' + cls + '">' + label + '</span>';
+}
+
+function applicationStatusBadge(status) {
+    var cls = 'status-badge ';
+    var label;
+    switch (status) {
+        case 'PENDING': cls += 'status-pending'; label = '대기'; break;
+        case 'ACCEPTED': cls += 'status-approved'; label = '수락'; break;
+        case 'REJECTED': cls += 'status-rejected'; label = '거절'; break;
+        default: cls += 'status-pending'; label = status || '-';
+    }
+    return '<span class="' + cls + '">' + label + '</span>';
+}
+
+function escapeHtml(str) {
+    if (!str) return '';
+    return String(str)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}

--- a/backend/src/main/resources/static/privacy.html
+++ b/backend/src/main/resources/static/privacy.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>딸바 개인정보처리방침</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; max-width: 720px; margin: 0 auto; padding: 24px; color: #333; }
+        h1 { font-size: 1.5rem; border-bottom: 2px solid #005BAA; padding-bottom: 8px; }
+        h2 { font-size: 1.2rem; margin-top: 24px; color: #005BAA; }
+        p, li { margin: 8px 0; }
+        ul { padding-left: 24px; }
+        .updated { color: #666; font-size: 0.9rem; }
+    </style>
+</head>
+<body>
+    <h1>딸바 개인정보처리방침</h1>
+    <p class="updated">시행일: 2026년 3월 13일</p>
+
+    <h2>1. 개요</h2>
+    <p>딸바(이하 "앱")는 사용자의 개인정보를 중요시하며, 「개인정보 보호법」 등 관련 법령을 준수합니다. 본 개인정보처리방침은 앱이 수집하는 정보와 그 이용 방법을 안내합니다.</p>
+
+    <h2>2. 수집하는 개인정보 항목</h2>
+    <ul>
+        <li><strong>필수 항목:</strong> 이메일, 비밀번호, 실명, 생년월일, 부산대 재학 여부</li>
+        <li><strong>선택 항목:</strong> 휴대전화번호, 학과, 학번, 프로필 사진</li>
+        <li><strong>소셜 로그인 시:</strong> 구글/카카오 계정 정보(이메일, 프로필 이미지 등)</li>
+        <li><strong>서비스 이용 시:</strong> 동아리 가입 정보, 게시글·댓글 작성 내용, FCM 토큰(푸시 알림용)</li>
+    </ul>
+
+    <h2>3. 개인정보의 이용 목적</h2>
+    <ul>
+        <li>회원 가입·인증 및 서비스 제공</li>
+        <li>동아리 관리, 일정·매칭 서비스 운영</li>
+        <li>커뮤니티(게시판, 댓글) 서비스 제공</li>
+        <li>푸시 알림 발송</li>
+        <li>서비스 개선 및 고객 문의 대응</li>
+    </ul>
+
+    <h2>4. 개인정보의 보유 및 파기</h2>
+    <p>회원 탈퇴 시 또는 수집 목적 달성 후 지체 없이 개인정보를 파기합니다. 단, 관련 법령에 따라 보존이 필요한 경우 해당 기간 동안 보관합니다.</p>
+
+    <h2>5. 개인정보의 제3자 제공</h2>
+    <p>딸바는 원칙적으로 사용자 동의 없이 개인정보를 제3자에게 제공하지 않습니다. 다만, 법령에 따른 요청이 있는 경우 예외로 합니다.</p>
+
+    <h2>6. 개인정보의 안전성 확보</h2>
+    <p>개인정보는 암호화·접근 제한 등 기술적·관리적 조치를 통해 안전하게 관리됩니다.</p>
+
+    <h2>7. 이용자 권리</h2>
+    <p>이용자는 언제든지 자신의 개인정보 열람·정정·삭제·처리정지를 요청할 수 있으며, 앱 내 설정 또는 고객 문의를 통해 행사할 수 있습니다.</p>
+
+    <h2>8. 만 13세 미만 아동</h2>
+    <p>본 서비스는 만 13세 미만 아동을 대상으로 하지 않으며, 해당 연령의 이용자로 확인될 경우 계정 생성이 제한될 수 있습니다.</p>
+
+    <h2>9. 문의</h2>
+    <p>개인정보 처리와 관련한 문의사항은 앱 내 고객센터 또는 개발팀으로 연락해 주시기 바랍니다.</p>
+
+    <p class="updated">※ 본 방침은 법령·정책 변경 시 수정될 수 있으며, 변경 시 앱 내 공지를 통해 안내합니다.</p>
+</body>
+</html>

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -78,16 +78,22 @@ cat ~/.ssh/deploy_key
 - `application-secret.yml` (비밀값) ← Git에 올리지 말고 서버에만 둠
 
 서버에 JAR와 같은 디렉터리에 `config/` 폴더를 만들어 설정을 넣습니다.
+**application-secret.yml은 반드시 서버에 수동으로 생성해야 합니다.** (Git에 없음)
 
 ```
 ~/PNUBasketballPlatform/
 ├── app.jar
 └── config/
-    ├── application-prod.yml   # app.token-storage: redis 등
-    └── application-secret.yml # DB, Redis, JWT, OAuth 비밀값 (Git에 없음)
+    ├── application-prod.yml   # app.token-storage: redis 등 (선택)
+    └── application-secret.yml # DB, Redis, JWT, OAuth 비밀값 ← 필수!
 ```
 
 Spring Boot는 `app.jar`와 같은 디렉터리의 `config/`를 자동으로 읽습니다.
+
+**application-secret.yml 생성 방법:**
+1. 로컬의 `backend/src/main/resources/application-secret.yml.example` 참고
+2. 서버에서 `mkdir -p ~/PNUBasketballPlatform/config`
+3. `config/application-secret.yml` 파일 생성 후 spring.datasource, jwt.secret 등 채우기
 
 **application-prod.yml** 예시 (`backend/src/main/resources/application-prod.yml.example` 참고):
 
@@ -111,5 +117,8 @@ GitHub → **Actions** → **Deploy Backend** → **Run workflow**
 |------|----------|
 | SSH 연결 실패 | `SSH_HOST`, `SSH_USER`, `SSH_PRIVATE_KEY` 확인, 서버 방화벽 22번 포트 개방 |
 | JAR 실행 실패 | 서버에서 `java -jar app.jar` 직접 실행해 에러 로그 확인 |
-| DB 연결 실패 | `application-prod.yml` DB URL, 사용자, 비밀번호 확인 |
+| **DataSource 'url' not specified** | `config/application-secret.yml`이 서버에 있는지 확인. 이 파일 없으면 DB 연결 불가. `application-secret.yml.example` 참고해 생성 |
+| DB 연결 실패 | `application-secret.yml`의 spring.datasource.url, username, password 확인 (RDS 보안그룹에서 서버 IP 허용 여부도 확인) |
+| Redis 연결 실패 | prod 프로파일 사용 시 Redis 필요. `config/application-secret.yml`에 redis.host/port 설정. Redis 미사용 시 `config/application-prod.yml`에 `app.token-storage: memory` 추가 |
+| Spring Data Redis 로그 노이즈 | local 프로파일 사용 시 `application-local.yml`이 Redis 자동설정을 비활성화함 |
 | 포트 충돌 | 기존 프로세스가 완전히 종료되지 않았을 수 있음 → `pkill -f app.jar` 후 재시작 |

--- a/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
+++ b/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
@@ -1,0 +1,618 @@
+# 매칭 시스템 기능 계획서
+
+> **작성일**: 2026-03-16  
+> **프로젝트**: 딸바 (PNU Basketball Platform)  
+> **핵심**: 레벨업 시스템, 게스트/번개 모집, 동아리 친선전, 노쇼 페널티
+
+---
+
+## 목차
+
+1. [시스템 개요](#1-시스템-개요)
+2. [공통 요구사항](#2-공통-요구사항)
+3. [게스트/사람 모으기 모집](#3-게스트사람-모으기-모집)
+4. [동아리 친선전](#4-동아리-친선전)
+5. [노쇼 페널티 시스템](#5-노쇼-페널티-시스템)
+6. [DB 및 도메인 설계](#6-db-및-도메인-설계)
+7. [API 설계](#7-api-설계)
+8. [구현 우선순위](#8-구현-우선순위)
+
+---
+
+## 1. 시스템 개요
+
+### 1.1 매칭 유형
+
+| 유형 | 점수 기록 | 경기 형식 | 설명 |
+|------|----------|----------|------|
+| **게스트/사람 모으기** | ❌ (참여 이력만) | 3:3, 4:4, 5:5, 모이는대로 | 번개, 즉석 농구, 결원 보충 |
+| **동아리 친선전** | ✅ 상세 기록 | 5:5만 | 팀 대 팀 공식 매치 |
+
+### 1.2 핵심 가치
+
+- **경험치(EXP) 시스템**: 게임할 때마다 경험치 누적. 등급/레벨은 나중에 EXP 구간으로 재미있게 나눌 수 있도록 **EXP만 저장**
+- **닉네임**: 모든 사용자에게 닉네임 필수 (모집/리뷰에서 노출)
+- **노쇼 페널티**: 모든 경기 공통 적용
+
+### 1.3 모집글과 실제 경기 분리
+
+> **모집글은 인원 모집을 위한 엔티티이며, 목표 인원 충족 및 확정 시 실제 일정/경기 엔티티로 승격 또는 연결될 수 있다.**
+
+| 엔티티 | 역할 |
+|--------|------|
+| **RecruitmentPost** | 사람 모으는 글 (수정 여러 번 가능, 인원 부족 시 취소 가능) |
+| **Match / ScheduledGame** | 실제 성사된 경기 (확정 시 생성) |
+| **Participation** | 실제 참가 이력 (경기 단위로 기록) |
+
+**플로우**: `모집글` → 확정 → `실제 경기 생성` → `참가 이력 기록`
+
+- recruitment_posts.status=CONFIRMED만으로 처리하면 일정 탭, 장소 중복 체크 등에서 복잡해짐
+- 확정 시 별도 `matches` 테이블에 경기를 생성하고, 참가 이력은 `matches` 기준으로 기록
+
+---
+
+## 2. 공통 요구사항
+
+### 2.1 사용자(User) 확장
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| **nickname** | varchar(30) | O | 닉네임 (앱 내 표시명, 모집/리뷰에 노출) |
+| **position** | enum | O | 주 포지션 (GUARD / FORWARD / CENTER) |
+| **exp** | int | O | 경험치 (누적) — DB에는 EXP만 저장 |
+| **no_show_count** | int | O | 노쇼 누적 횟수 |
+| **participation_count** | int | O | 참여 완료 횟수 |
+
+**기존 User 필드**: real_name, email, wins, games, total_score 등 유지  
+**닉네임 vs 실명**: real_name은 본명(인증용), nickname은 앱 내 활동용
+
+> **nickname, position은 회원가입 중 "필수정보 입력" 단계에서 반드시 입력해야 한다.**  
+> 기존 completeProfile 플로우에 nickname, position 필드를 추가한다.
+
+> **레벨/등급은 DB에 저장하지 않음.**  
+> 나중에 EXP 구간으로 재미있게 나눌 수 있음 (예: 0~99=루키, 100~299=슈터, 300~=올스타 등).  
+> **체크/로직은 경험치(exp)만 사용.**
+
+### 2.2 경험치(EXP) 시스템
+
+| 항목 | 설명 |
+|------|------|
+| **경험치 부여** | 게스트/번개 참여 완료 시 +EXP, 동아리전 참여 시 +EXP (더 높음) |
+| **등급/레벨** | DB에 저장 X. 필요 시 EXP 구간으로 앱에서 계산 |
+| **노출** | 프로필, 모집글 신청자 목록에 "EXP 150 닉네임" 또는 "등급 닉네임" 형태 |
+
+**경험치 부여 예시**
+
+```
+게스트/번개 참여 완료: +10 EXP
+동아리전 참여 시: +30 EXP
+(등급/레벨은 나중에 EXP 구간으로 재미있게 정의 가능)
+```
+
+---
+
+## 3. 게스트/사람 모으기 모집
+
+### 3.1 개요
+
+- **점수 기록**: 하지 않음. "참여했었다" 이력만 저장
+- **경기 형태**: 3:3, 4:4, 5:5, 모이는대로
+
+### 3.2 필요한 정보
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| 시작 시각 | start_at | O | 경기 시작 (datetime) |
+| 종료 시각 | end_at | O | 경기 종료 (datetime) — 장소 중복 체크, 일정 표시에 필요 |
+| 장소 | location_id | O | **있는 장소에서 선택** (schedule_locations 참조) |
+| 현재 확정 인원 | int | O | 이미 있는 인원 |
+| 필요한 인원 | int | O | 모집 인원 |
+| 포지션 | multi-select | △ | 가드/포워드/센터 우대 |
+| 경기 형태 | enum | O | THREE_VS_THREE, FOUR_VS_FOUR, FIVE_VS_FIVE, FLEXIBLE |
+| 모집 마감 시간 | datetime | △ | 마감 시각 |
+
+### 3.3 필요 기능
+
+#### 1) 모집 진행률 시각화
+
+```
+┌─────────────────────────────────────┐
+│  현재 3 / 6명                        │
+│  ████████████░░░░░░  50%            │
+│  3명 더 모이면 확정!                 │
+└─────────────────────────────────────┘
+```
+
+- 실시간 인원 수 반영
+- 목표 인원 도달 여부는 **상태가 아닌 계산값** (`accepted_count >= needed_members`)
+- "FULL" 뱃지는 UI에서만 표시, DB 상태로 관리하지 않음
+- 모집자가 최종 확정 버튼 → `OPEN` → `CONFIRMED` → matches 생성
+
+#### 2) 폼 기반 모집 신청
+
+- 텍스트 게시판 X, 입력 필드 O
+- 신청 시: 한줄 메시지 선택형 ("가드 가능", "바로 갈 수 있음" 등)
+- 모집자: 신청자 프로필(닉네임, EXP, 참여율, 노쇼 횟수) 확인 후 수락/거절
+
+#### 3) 경기 후 상대에게 리뷰
+
+- **참여 완료** 시에만 리뷰 가능
+- 같은 경기에 참여한 상대에게만 리뷰 작성
+- 리뷰 항목: 매너 점수(1~5), 한줄 코멘트(선택)
+- 리뷰는 익명 X → "닉네임(EXP 150)이 리뷰함" 형태 (신뢰성)
+
+### 3.4 참여 이력 저장
+
+| 테이블 | 설명 |
+|--------|------|
+| **matches** | 실제 확정된 경기 (모집글 확정 시 생성) |
+| **match_participations** | 경기별 참가 이력 (점수 없음) — **matches** 참조 |
+| - match_id | 실제 경기 ID |
+| - user_id | |
+| - status | ATTENDED / NO_SHOW |
+
+---
+
+## 4. 동아리 친선전
+
+### 4.1 개요
+
+- **점수 기록**: 상세 기록 (득점, 승패 등)
+- **경기 형식**: 5:5만
+
+### 4.2 필요한 정보
+
+| 필드 | 타입 | 필수 | 설명 |
+|------|------|------|------|
+| 신청 동아리 (홈팀) | club_id | O | 친선전을 신청하는 동아리 |
+| 시작 시각 | start_at | O | 경기 시작 (datetime) |
+| 종료 시각 | end_at | O | 경기 종료 (datetime) |
+| 장소 | location_id | O | **있는 장소에서 선택** (schedule_locations 참조) |
+| 상대 동아리 | club_id | △ | 지정 시 바로 매칭, 미지정 시 모집 |
+
+### 4.3 펀딩형 출석 조건
+
+> **같은 동아리 소속인 5명 이상 모여야 상대 동아리로 지정 가능**
+
+| 단계 | 설명 |
+|------|------|
+| 1 | 홈팀 대표가 친선전 신청 (날짜, 장소) |
+| 2 | 동아리 멤버가 "참가 의사" 등록 |
+| 3 | **5명 이상** 모이면 → 상대 동아리 지정 가능 (매칭 풀에 노출) |
+| 4 | 상대 동아리도 5명 이상 모이면 → 매칭 확정 |
+| 5 | 경기 진행 → 결과 입력 |
+
+### 4.4 필요 기능
+
+#### 1) 경기 후 결과 입력
+
+- **입력 내용**: 홈팀 점수 N : 원정팀 점수 N
+- **승인 플로우**: 
+  1. 홈팀 대표가 결과 입력 (예: 72 : 68)
+  2. 원정팀 대표가 결과 확인 및 승인
+  3. **두 동아리 대표가 모두 승인** → 관리자 탭에서 최종 기록
+
+#### 2) 관리자 탭
+
+- 대표 양측 승인된 경기 목록
+- 승인 시 `club_matches`에 기록, `clubs.wins` 업데이트
+- 이력 추적 (누가 언제 승인했는지)
+
+### 4.5 상태 흐름
+
+```
+[홈팀 신청] → [참가 의사 5명↑] → [상대 지정 가능]
+    → [상대팀 매칭] → [양측 5명↑] → [경기 확정]
+    → [경기 진행] → [결과 입력] → [양측 대표 승인] → [관리자 기록]
+```
+
+---
+
+## 5. 노쇼 페널티 시스템
+
+### 5.1 적용 범위
+
+- **모든 경기**에 적용 (게스트/번개, 동아리 친선전)
+
+### 5.2 노쇼 정의
+
+| 상황 | 노쇼 여부 |
+|------|-----------|
+| 신청 후 수락됐는데 경기 불참 | O (노쇼) |
+| 사전 취소 (N시간 전) | X (정상 취소) |
+| 경기 당일 무단 불참 | O (노쇼) |
+
+### 5.3 페널티 내용
+
+| 항목 | 설명 |
+|------|------|
+| **노쇼 카운트** | users.no_show_count 증가 |
+| **프로필 노출** | "최근 10회 중 노쇼 0회" 등 표시 |
+| **모집자 참고** | 신청자 목록에서 노쇼 횟수 확인 가능 |
+| **제재** | N회 이상 시 모집 참여 제한 (선택) |
+
+### 5.4 필요 기능
+
+| 기능 | 설명 |
+|------|------|
+| 노쇼 신고 | 모집자/팀 대표가 "노쇼" 신고 |
+| 노쇼 확인 | 관리자 또는 자동(경기 후 미체크인 시) |
+| 노쇼 이력 조회 | 사용자별 노쇼 이력 (관리자용) |
+
+---
+
+## 6. DB 및 도메인 설계
+
+### 6.1 DB 마이그레이션 시각화
+
+#### 현재 (Before) → 이후 (After)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  users (현재)                                                                                     │
+├─────────────────────────────────────────────────────────────────────────────────────────────────┤
+│  user_id (PK)  │ email  │ real_name  │ wins  │ games  │ total_score  │ ...  │ (fcm_token 등)     │
+└─────────────────────────────────────────────────────────────────────────────────────────────────┘
+                                                    │
+                                                    │  ALTER TABLE (컬럼 추가)
+                                                    ▼
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  users (이후)                                                                                     │
+├─────────────────────────────────────────────────────────────────────────────────────────────────┤
+│  user_id (PK)  │ email  │ real_name  │ wins  │ games  │ total_score  │ ...  │ (기존)             │
+│  + nickname    │ + position  │ + exp  │ + no_show_count  │ + participation_count  │ (신규)     │
+└─────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 마이그레이션 요약 (시각적)
+
+```
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  📦 1. users 테이블 변경 (ALTER)                                                                  │
+├─────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                                  │
+│   users  ────────────────────────────────────────────────────────────────────────────────────   │
+│                                                                                                  │
+│   [기존 컬럼]                      [추가 컬럼]                                                  │
+│   • user_id                        • nickname      VARCHAR(30) UNIQUE                           │
+│   • email                          • position      VARCHAR(20) NOT NULL (GUARD/FORWARD/CENTER)  │
+│   • real_name                      • exp           INTEGER DEFAULT 0                             │
+│   • real_name                      • no_show_count INTEGER DEFAULT 0                             │
+│   • wins, games, total_score       • participation_count INTEGER DEFAULT 0                      │
+│   • ...                                                                                          │
+│                                                                                                  │
+│   ⚠️ level 컬럼 없음 — 등급/레벨은 나중에 exp 구간으로 앱에서 계산                               │
+│                                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  📦 2. 신규 테이블 (CREATE)                                                         │
+├─────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                                  │
+│   recruitment_posts ◄── users (author_id), schedule_locations (location_id)                      │
+│         │                                                                                        │
+│         ├── recruitment_applications ◄── users (applicant_id)                                    │
+│         │                                                                                        │
+│         └── (확정 시) matches 생성 ◄── recruitment_posts 또는 club_match_requests                │
+│                   │                                                                              │
+│                   ├── match_participations ◄── users (실제 경기 참가 이력)                        │
+│                   │         └── participation_reviews                                            │
+│                   └── no_show_reports (match_id 기준)                                             │
+│                                                                                                  │
+│   club_match_requests ◄────────── clubs (home/away), schedule_locations (location_id)           │
+│         │                                                                                        │
+│         ├── club_match_attendances ◄── users, clubs                                             │
+│         │                                                                                        │
+│         └── club_match_results ◄───── club_match_requests                                       │
+│                                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────────────────────────────────────────┐
+│  📦 3. ER 관계도 (시각적)                                                                         │
+├─────────────────────────────────────────────────────────────────────────────────────────────────┤
+│                                                                                                  │
+│      users ───────────────────────────────────────────────────────────────────────────────────   │
+│        │                                                                                         │
+│        ├── author ───────────────────► recruitment_posts                                        │
+│        │                                    │                                                    │
+│        │                                    ├── applications (applicant)                         │
+│        │                                    ├── match_participations                              │
+│        │                                    │       └── participation_reviews                   │
+│        │                                    └── no_show_reports                                  │
+│        │                                                                                         │
+│        └── club_members ─────────────► clubs                                                     │
+│                                            │                                                     │
+│                                            └── club_match_requests (home/away)                   │
+│                                                    ├── club_match_attendances                    │
+│                                                    └── club_match_results                        │
+│                                                                                                  │
+└─────────────────────────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 마이그레이션 실행 순서
+
+```
+※ schedule_locations는 schema.sql에 이미 존재 (넉넉한터, 온천천 등). 별도 생성 불필요.
+
+1단계: users 확장
+   └── V001__add_users_matching_fields.sql
+
+2단계: 모집 관련 ENUM
+   └── recruitment_game_format, recruitment_status
+
+3단계: recruitment_posts, recruitment_applications
+   └── V002__create_recruitment_posts.sql
+
+4단계: club_match_requests, club_match_attendances, club_match_results
+   └── V003__create_club_match_requests.sql
+
+5단계: matches, match_participations, participation_reviews, no_show_reports
+   └── V004__create_matches_and_participations.sql
+```
+
+### 6.2 User 확장 (SQL)
+
+```sql
+-- level 컬럼 없음. exp만 저장. 등급/레벨은 나중에 exp 구간으로 앱에서 계산
+ALTER TABLE users ADD COLUMN IF NOT EXISTS nickname VARCHAR(30) UNIQUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS position VARCHAR(20);  -- GUARD, FORWARD, CENTER
+ALTER TABLE users ADD COLUMN IF NOT EXISTS exp INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS no_show_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS participation_count INTEGER NOT NULL DEFAULT 0;
+-- nickname, position은 회원가입 필수정보 입력 단계(completeProfile)에서 필수
+```
+
+### 6.3 게스트/번개 모집
+
+```sql
+CREATE TYPE recruitment_game_format AS ENUM ('THREE_VS_THREE', 'FOUR_VS_FOUR', 'FIVE_VS_FIVE', 'FLEXIBLE');
+-- 상태는 단순하게. FULL은 계산값(accepted_count >= needed_members)으로 UI 뱃지만 표시
+CREATE TYPE recruitment_status AS ENUM ('OPEN', 'CONFIRMED', 'CLOSED', 'CANCELLED');
+
+CREATE TABLE recruitment_posts (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    author_id       BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    start_at        TIMESTAMP NOT NULL,   -- 경기 시작 (datetime) — 장소 중복 체크, 일정 표시에 필요
+    end_at          TIMESTAMP NOT NULL,   -- 경기 종료 (datetime)
+    location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,  -- 있는 장소에서 선택
+    current_members INTEGER NOT NULL,
+    needed_members INTEGER NOT NULL,
+    game_format     recruitment_game_format NOT NULL,
+    deadline_at     TIMESTAMP,
+    status          recruitment_status NOT NULL DEFAULT 'OPEN',
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_recruitment_time CHECK (start_at < end_at)
+);
+
+CREATE TABLE recruitment_applications (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    recruitment_id  UUID NOT NULL REFERENCES recruitment_posts(id) ON DELETE CASCADE,
+    applicant_id    BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- PENDING, ACCEPTED, REJECTED
+    message         VARCHAR(200),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(recruitment_id, applicant_id)
+);
+```
+
+### 6.4 동아리 친선전
+
+```sql
+-- 친선전 신청 (홈팀이 먼저 생성)
+CREATE TABLE club_match_requests (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    home_club_id    UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    start_at        TIMESTAMP NOT NULL,   -- 경기 시작 (datetime)
+    end_at          TIMESTAMP NOT NULL,  -- 경기 종료 (datetime)
+    location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,  -- 있는 장소에서 선택
+    status          VARCHAR(20) NOT NULL DEFAULT 'GATHERING',
+    -- GATHERING: 홈팀 인원 모집 중
+    -- READY:     홈팀 5인 이상 확보, 상대 지정 가능
+    -- MATCHED:   상대팀 지정 완료
+    -- CONFIRMED: 양팀 5인 이상 확보, 일정 확정
+    -- DONE:      경기 종료
+    -- CANCELLED: 취소
+    away_club_id    UUID REFERENCES clubs(id) ON DELETE SET NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_club_match_request_time CHECK (start_at < end_at)
+);
+
+-- 동아리별 참가 의사 (5명 모이기)
+CREATE TABLE club_match_attendances (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    request_id      UUID NOT NULL REFERENCES club_match_requests(id) ON DELETE CASCADE,
+    club_id         UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    user_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(request_id, club_id, user_id)
+);
+
+-- 경기 결과 (양측 승인 대기)
+CREATE TABLE club_match_results (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    request_id      UUID NOT NULL REFERENCES club_match_requests(id) ON DELETE CASCADE UNIQUE,
+    home_score      INTEGER NOT NULL,
+    away_score      INTEGER NOT NULL,
+    home_approved   BOOLEAN NOT NULL DEFAULT FALSE,
+    away_approved   BOOLEAN NOT NULL DEFAULT FALSE,
+    admin_approved  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- club_matches는 양측+관리자 승인 후 최종 기록 (기존 테이블 활용)
+```
+
+### 6.5 matches (실제 경기) 및 참가 이력
+
+```sql
+-- 실제 확정된 경기 (모집글/동아리전 확정 시 생성)
+CREATE TABLE matches (
+    id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    source_type         VARCHAR(20) NOT NULL,  -- RECRUITMENT, CLUB_MATCH
+    recruitment_id      UUID REFERENCES recruitment_posts(id) ON DELETE SET NULL,   -- 게스트/번개 확정 시
+    club_match_request_id UUID REFERENCES club_match_requests(id) ON DELETE SET NULL,  -- 동아리전 확정 시
+    location_id         UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
+    start_at            TIMESTAMP NOT NULL,
+    end_at              TIMESTAMP NOT NULL,
+    game_format         recruitment_game_format,  -- 게스트/번개만 (동아리전은 5:5 고정)
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_match_time CHECK (start_at < end_at),
+    CONSTRAINT chk_match_source CHECK (
+        (source_type = 'RECRUITMENT' AND recruitment_id IS NOT NULL AND club_match_request_id IS NULL) OR
+        (source_type = 'CLUB_MATCH' AND club_match_request_id IS NOT NULL AND recruitment_id IS NULL)
+    )
+);
+
+-- 참가 이력 (실제 경기 기준)
+CREATE TABLE match_participations (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    match_id        UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    user_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status          VARCHAR(20) NOT NULL,  -- ATTENDED, NO_SHOW
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(match_id, user_id)
+);
+
+-- 리뷰 (경기 참가자에 대한 리뷰)
+CREATE TABLE participation_reviews (
+    id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    participation_id    UUID NOT NULL REFERENCES match_participations(id) ON DELETE CASCADE,
+    reviewer_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    reviewee_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    manner_score        INTEGER NOT NULL CHECK (manner_score BETWEEN 1 AND 5),
+    comment             VARCHAR(200),
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(participation_id, reviewer_id, reviewee_id)
+);
+
+-- 노쇼 신고 (실제 경기 기준)
+CREATE TABLE no_show_reports (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    match_id        UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    reporter_id     BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    reported_user_id BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- PENDING, CONFIRMED, REJECTED
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+### 6.6 포지션 (선택)
+
+```sql
+-- 포지션 enum 또는 테이블
+CREATE TYPE position_type AS ENUM ('GUARD', 'FORWARD', 'CENTER');
+
+-- recruitment_posts에 preferred_positions (배열 또는 junction)
+CREATE TABLE recruitment_preferred_positions (
+    recruitment_id  UUID NOT NULL REFERENCES recruitment_posts(id) ON DELETE CASCADE,
+    position        position_type NOT NULL,
+    PRIMARY KEY (recruitment_id, position)
+);
+```
+
+---
+
+## 7. API 설계
+
+### 7.1 게스트/번개 모집
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | /api/recruitments | 모집글 생성 |
+| GET | /api/recruitments | 목록 조회 (필터: start_at~end_at, 장소, 경기형태) |
+| GET | /api/recruitments/{id} | 상세 (진행률 포함) |
+| POST | /api/recruitments/{id}/apply | 신청 |
+| POST | /api/recruitments/{id}/applications/{userId}/accept | 수락 |
+| POST | /api/recruitments/{id}/applications/{userId}/reject | 거절 |
+| POST | /api/recruitments/{id}/confirm | 모집 확정 → matches 생성 |
+| POST | /api/matches/{id}/complete | 경기 완료 처리 |
+| POST | /api/matches/{id}/reviews | 참여자에게 리뷰 |
+| POST | /api/matches/{id}/no-show | 노쇼 신고 |
+
+### 7.2 실제 경기 (matches)
+
+| Method | Path | 설명 |
+|--------|------|------|
+| GET | /api/matches | 내 확정 경기 목록 (일정 탭용) |
+| GET | /api/matches/{id} | 경기 상세 |
+
+### 7.3 동아리 친선전
+
+| Method | Path | 설명 |
+|--------|------|------|
+| POST | /api/club-matches/requests | 친선전 신청 (홈팀) |
+| POST | /api/club-matches/requests/{id}/attend | 참가 의사 등록 |
+| GET | /api/club-matches/requests | 신청 목록 (5명↑인 것만 상대 지정 가능) |
+| POST | /api/club-matches/requests/{id}/match | 상대 동아리 지정 |
+| POST | /api/club-matches/requests/{id}/result | 결과 입력 |
+| POST | /api/club-matches/requests/{id}/approve-result | 대표 승인 |
+| GET | /api/admin/club-matches/pending | 관리자: 승인 대기 목록 |
+| POST | /api/admin/club-matches/{id}/confirm | 관리자: 최종 기록 |
+
+### 7.4 사용자
+
+| Method | Path | 설명 |
+|--------|------|------|
+| PATCH | /api/users/me | 프로필 수정 (nickname, position 포함) |
+| GET | /api/users/{id}/profile | 공개 프로필 (닉네임, 포지션, EXP, 참여율, 노쇼) |
+
+---
+
+## 8. 구현 우선순위
+
+### Phase 1: 기반 구축
+
+| 순서 | 항목 | 설명 |
+|------|------|------|
+| 1 | User 확장 | nickname, position, exp, no_show_count, participation_count |
+| 2 | 경험치 로직 | 참여 완료 시 EXP 부여 (레벨/등급은 DB에 저장 X) |
+| 3 | 필수정보 입력 | 회원가입 completeProfile 단계에 nickname, position 추가 |
+
+### Phase 2: 게스트/번개 모집
+
+| 순서 | 항목 | 설명 |
+|------|------|------|
+| 1 | recruitment_posts CRUD | 모집글 생성, 조회 (start_at, end_at) |
+| 2 | 신청/수락/거절 | applications, 진행률 계산 |
+| 3 | 진행률 시각화 | API 응답에 current/needed 포함 |
+| 4 | 확정 → matches 생성 | 목표 인원 충족 시 matches 테이블에 경기 생성 |
+| 5 | match_participations | 실제 경기 기준 참가 이력 저장 |
+| 6 | 리뷰 기능 | participation_reviews (match 기준) |
+| 7 | 노쇼 신고 | no_show_reports (match_id 기준), users.no_show_count 업데이트 |
+
+### Phase 3: 동아리 친선전
+
+| 순서 | 항목 | 설명 |
+|------|------|------|
+| 1 | club_match_requests | 친선전 신청 |
+| 2 | club_match_attendances | 5명 모이기 |
+| 3 | 상대 지정/매칭 | 5명↑ 시 상대 지정 가능 |
+| 4 | club_match_results | 결과 입력, 양측 승인 |
+| 5 | 관리자 승인 | club_matches 기록, clubs.wins 업데이트 |
+
+### Phase 4: 노쇼 페널티 통합
+
+| 순서 | 항목 | 설명 |
+|------|------|------|
+| 1 | 동아리전 노쇼 | club_match_attendances에서 실제 참석 여부 |
+| 2 | 노쇼 신고 플로우 | 게스트/동아리전 공통 |
+| 3 | 제재 정책 | N회 이상 시 제한 (선택) |
+
+---
+
+## 부록: 요약 체크리스트
+
+- [ ] **닉네임 + 포지션** 필수 (User 확장, 회원가입 필수정보 입력 단계)
+- [ ] **경험치(EXP)** 시스템 (경기 참여 시 EXP, 레벨/등급은 DB에 저장 X)
+- [ ] **게스트/번개**: start_at/end_at, 장소(location_id), 인원, 포지션, 경기형태, 마감
+- [ ] **진행률 시각화** (3/6명)
+- [ ] **폼 기반 신청** + 수락/거절
+- [ ] **경기 후 리뷰** (상대에게)
+- [ ] **동아리 친선전**: 5명↑ 모여야 상대 지정, 5:5만
+- [ ] **결과 입력** → 양측 대표 승인 → 관리자 기록
+- [ ] **노쇼 페널티** (모든 경기)
+- [ ] **모집글 ↔ 실제 경기 분리** (확정 시 matches 생성)

--- a/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
+++ b/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
@@ -12,7 +12,7 @@
 2. [공통 요구사항](#2-공통-요구사항)
 3. [게스트/사람 모으기 모집](#3-게스트사람-모으기-모집)
 4. [동아리 친선전](#4-동아리-친선전)
-5. [노쇼 페널티 시스템](#5-노쇼-페널티-시스템)
+5. [경기 종료 후 리뷰 + 노쇼 시스템](#5-경기-종료-후-리뷰--노쇼-시스템)
 6. [DB 및 도메인 설계](#6-db-및-도메인-설계)
 7. [API 설계](#7-api-설계)
 8. [구현 우선순위](#8-구현-우선순위)
@@ -44,10 +44,19 @@
 | **Match / ScheduledGame** | 실제 성사된 경기 (확정 시 생성) |
 | **Participation** | 실제 참가 이력 (경기 단위로 기록) |
 
-**플로우**: `모집글` → 확정 → `실제 경기 생성` → `참가 이력 기록`
+**플로우**:
+
+```
+모집글 → 확정 → 실제 경기(matches) 생성 → 일정(schedules)에 자동 등록 → 참가 이력 기록
+```
 
 - recruitment_posts.status=CONFIRMED만으로 처리하면 일정 탭, 장소 중복 체크 등에서 복잡해짐
 - 확정 시 별도 `matches` 테이블에 경기를 생성하고, 참가 이력은 `matches` 기준으로 기록
+- **matches 생성 시 `schedules` 테이블에도 일정을 자동 등록**하여 일정 탭과 연계
+  - `schedules.match_id` = `matches.id` (기존 스키마에 이미 match_id 컬럼 존재)
+  - `schedules.schedule_type` = 'MATCH'
+  - `schedules.status` = 'SCHEDULED'
+  - 일정 탭에서 기존 일반 일정과 매칭 확정 일정을 함께 표시
 
 ---
 
@@ -134,12 +143,10 @@
 - 신청 시: 한줄 메시지 선택형 ("가드 가능", "바로 갈 수 있음" 등)
 - 모집자: 신청자 프로필(닉네임, EXP, 참여율, 노쇼 횟수) 확인 후 수락/거절
 
-#### 3) 경기 후 상대에게 리뷰
+#### 3) 경기 종료 후 리뷰 + 노쇼 신고
 
-- **참여 완료** 시에만 리뷰 가능
-- 같은 경기에 참여한 상대에게만 리뷰 작성
-- 리뷰 항목: 매너 점수(1~5), 한줄 코멘트(선택)
-- 리뷰는 익명 X → "닉네임(EXP 150)이 리뷰함" 형태 (신뢰성)
+- 모든 매칭(게스트/번개, 동아리 친선전) 공통으로 적용
+- 상세는 **5장 "경기 종료 후 리뷰 + 노쇼 팝업"** 참조
 
 ### 3.4 참여 이력 저장
 
@@ -204,17 +211,74 @@
 [홈팀 신청] → [참가 의사 5명↑] → [상대 지정 가능]
     → [상대팀 매칭] → [양측 5명↑] → [경기 확정]
     → [경기 진행] → [결과 입력] → [양측 대표 승인] → [관리자 기록]
+    → [경기 종료 후] → [리뷰 + 노쇼 팝업] (5장 참조)
 ```
 
 ---
 
-## 5. 노쇼 페널티 시스템
+## 5. 경기 종료 후 리뷰 + 노쇼 시스템
 
-### 5.1 적용 범위
+> **모든 매칭(게스트/번개, 동아리 친선전)에 공통 적용.**  
+> matches 테이블에 경기가 생성된 이상, 종류 구분 없이 동일한 리뷰+노쇼 팝업이 뜬다.
+
+### 5.1 리뷰 + 노쇼 팝업
+
+경기 종료 시각(`end_at`) 이후 앱 접속 시 참가자에게 **리뷰 팝업**이 자동으로 뜬다.
+
+**팝업 구조 (모바일 바텀시트/다이얼로그)**
+
+```
+┌──────────────────────────────────────────────┐
+│  🏀 경기가 끝났어요! 함께한 사람들을 평가해주세요  │
+│                                               │
+│  ── 우리 팀 ──────────────────────────────── │
+│  ┌────────────────────────────────────────┐  │
+│  │  닉네임A (가드)          👍            │  │
+│  │  닉네임B (포워드)        👍            │  │
+│  │  닉네임C (센터)          👍            │  │
+│  └────────────────────────────────────────┘  │
+│                                               │
+│  ── 상대 팀 ──────────────────────────────── │
+│  ┌────────────────────────────────────────┐  │
+│  │  닉네임D (가드)          👍            │  │
+│  │  닉네임E (포워드)        👍            │  │
+│  │  닉네임F (센터)          👍   ⚠️노쇼   │  │
+│  └────────────────────────────────────────┘  │
+│                                               │
+│             [ 제출하기 ]                       │
+└──────────────────────────────────────────────┘
+```
+
+**UX 원칙**
+
+- **따봉(👍) 방식**: 점수 X. 좋았으면 👍 누르기 (1), 안 누르면 (0)
+- **간단함**: 한 화면에서 모든 참가자 한 번에 평가
+- **우리 팀 / 상대 팀** 구분 표시 (한 눈에 보기 쉽게)
+- **노쇼 신고 버튼**: 각 참가자 옆에 "⚠️노쇼" 버튼 (안 나왔으면 누르기)
+- 리뷰 제출은 **선택** (건너뛰기 가능), 노쇼 신고만 별도 가능
+
+**타이밍**
+
+- 경기 종료 시각(`end_at`) 이후 앱 접속 시 팝업 노출
+- 제출 안 했으면 "내 매치" 탭에서 다시 접근 가능
+- 리뷰 기한: 경기 종료 후 24시간 이내
+
+**매칭 유형별 차이**
+
+| 항목 | 게스트/번개 | 동아리 친선전 |
+|------|------------|-------------|
+| 팝업 구조 | 동일 | 동일 |
+| 우리 팀/상대 팀 | 모집자 vs 참가자 또는 랜덤 편 | 홈팀 vs 원정팀 (동아리 기준) |
+| 따봉 대상 | 모든 참가자 | 모든 참가자 |
+| 노쇼 신고 | 모든 참가자 | 모든 참가자 |
+
+### 5.2 노쇼 페널티
+
+#### 적용 범위
 
 - **모든 경기**에 적용 (게스트/번개, 동아리 친선전)
 
-### 5.2 노쇼 정의
+#### 노쇼 정의
 
 | 상황 | 노쇼 여부 |
 |------|-----------|
@@ -222,7 +286,7 @@
 | 사전 취소 (N시간 전) | X (정상 취소) |
 | 경기 당일 무단 불참 | O (노쇼) |
 
-### 5.3 페널티 내용
+#### 페널티 내용
 
 | 항목 | 설명 |
 |------|------|
@@ -231,12 +295,18 @@
 | **모집자 참고** | 신청자 목록에서 노쇼 횟수 확인 가능 |
 | **제재** | N회 이상 시 모집 참여 제한 (선택) |
 
-### 5.4 필요 기능
+#### 노쇼 신고 방법
+
+- **리뷰 팝업에 통합**: 경기 종료 후 리뷰 팝업에서 각 참가자 옆에 "⚠️노쇼" 버튼
+- 안 나온 사람이 있으면 해당 버튼을 누르는 것만으로 신고 완료
+- 별도 신고 화면 없이 리뷰와 같은 화면에서 처리
+
+#### 필요 기능
 
 | 기능 | 설명 |
 |------|------|
-| 노쇼 신고 | 모집자/팀 대표가 "노쇼" 신고 |
-| 노쇼 확인 | 관리자 또는 자동(경기 후 미체크인 시) |
+| 노쇼 신고 | 리뷰 팝업에서 참가자별 "⚠️노쇼" 버튼 |
+| 노쇼 확인 | 복수 참가자가 같은 사람을 신고 시 자동 확정 (또는 관리자 확인) |
 | 노쇼 이력 조회 | 사용자별 노쇼 이력 (관리자용) |
 
 ---
@@ -295,6 +365,7 @@
 │         │                                                                                        │
 │         └── (확정 시) matches 생성 ◄── recruitment_posts 또는 club_match_requests                │
 │                   │                                                                              │
+│                   ├── schedules (일정 자동 등록, match_id ↔ schedule_id 양방향)                    │
 │                   ├── match_participations ◄── users (실제 경기 참가 이력)                        │
 │                   │         └── participation_reviews                                            │
 │                   └── no_show_reports (match_id 기준)                                             │
@@ -454,6 +525,7 @@ CREATE TABLE matches (
     source_type         VARCHAR(20) NOT NULL,  -- RECRUITMENT, CLUB_MATCH
     recruitment_id      UUID REFERENCES recruitment_posts(id) ON DELETE SET NULL,   -- 게스트/번개 확정 시
     club_match_request_id UUID REFERENCES club_match_requests(id) ON DELETE SET NULL,  -- 동아리전 확정 시
+    schedule_id         UUID REFERENCES schedules(id) ON DELETE SET NULL,  -- 일정 연동 (확정 시 자동 생성)
     location_id         UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
     start_at            TIMESTAMP NOT NULL,
     end_at              TIMESTAMP NOT NULL,
@@ -467,6 +539,12 @@ CREATE TABLE matches (
     )
 );
 
+-- ※ 매치 확정 시 서비스 로직에서 아래를 동시에 수행:
+--   1. matches INSERT
+--   2. schedules INSERT (schedule_type='MATCH', match_id=matches.id)
+--   3. matches.schedule_id = 생성된 schedules.id
+-- → schedules.match_id ↔ matches.schedule_id 양방향 참조로 일정 탭과 완전 연계
+
 -- 참가 이력 (실제 경기 기준)
 CREATE TABLE match_participations (
     id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -477,16 +555,15 @@ CREATE TABLE match_participations (
     UNIQUE(match_id, user_id)
 );
 
--- 리뷰 (경기 참가자에 대한 리뷰)
+-- 리뷰 (따봉 방식: 1=👍, 0=미평가)
 CREATE TABLE participation_reviews (
     id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    participation_id    UUID NOT NULL REFERENCES match_participations(id) ON DELETE CASCADE,
+    match_id            UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
     reviewer_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     reviewee_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    manner_score        INTEGER NOT NULL CHECK (manner_score BETWEEN 1 AND 5),
-    comment             VARCHAR(200),
+    thumbs_up           BOOLEAN NOT NULL DEFAULT FALSE,  -- true=👍, false=미평가
     created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    UNIQUE(participation_id, reviewer_id, reviewee_id)
+    UNIQUE(match_id, reviewer_id, reviewee_id)
 );
 
 -- 노쇼 신고 (실제 경기 기준)
@@ -500,7 +577,154 @@ CREATE TABLE no_show_reports (
 );
 ```
 
-### 6.6 포지션 (선택)
+### 6.6 일정(schedules) 연동 상세
+
+#### 현재 schedules 구조 (schema.sql 기준)
+
+```
+schedules (기존)
+├── id              UUID PK
+├── location_id     UUID FK → schedule_locations  (장소)
+├── schedule_date   DATE                          (날짜)
+├── start_time      TIME                          (시작 시간)
+├── end_time        TIME                          (종료 시간)
+├── status          ENUM (AVAILABLE, SCHEDULED, CANCELLED)
+├── schedule_type   VARCHAR (REGULAR, TRAINING)   ← 'MATCH' 추가 예정
+├── title           VARCHAR
+├── description     TEXT
+├── match_id        UUID                          ← 이미 존재 (현재 미사용)
+├── created_at, updated_at
+```
+
+**핵심**: `schedule_type`에 `'MATCH'` 값 추가, `match_id`에 `matches.id` 연결만 하면 기존 구조 그대로 활용 가능.
+
+#### 기존 엔티티 (Schedule.java)
+
+```
+Schedule.java (현재 구현)
+├── location      → ScheduleLocationEntity (ManyToOne)
+├── scheduleDate  → LocalDate
+├── startTime     → LocalTime
+├── endTime       → LocalTime
+├── status        → ScheduleStatus (AVAILABLE, SCHEDULED, CANCELLED)
+├── scheduleType  → String ("REGULAR", "TRAINING")
+├── title, description
+├── matchId       → UUID (이미 필드 존재, 현재 null)
+```
+
+#### 매치 확정 시 연동 플로우
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│  1. 모집 확정 (recruitment_posts.status → CONFIRMED)                        │
+│     또는 동아리전 확정 (club_match_requests.status → CONFIRMED)              │
+│                                                                              │
+│  2. matches 테이블에 INSERT                                                 │
+│     ├── source_type, recruitment_id/club_match_request_id                    │
+│     ├── location_id, start_at, end_at, game_format                           │
+│     └── schedule_id (3단계에서 채움)                                         │
+│                                                                              │
+│  3. schedules 테이블에 INSERT (일정 자동 등록)                               │
+│     ├── location_id    = matches.location_id                                 │
+│     ├── schedule_date  = matches.start_at의 날짜 부분                        │
+│     ├── start_time     = matches.start_at의 시간 부분                        │
+│     ├── end_time       = matches.end_at의 시간 부분                          │
+│     ├── status         = 'SCHEDULED'                                        │
+│     ├── schedule_type  = 'MATCH'              ← 신규 값                      │
+│     ├── title          = "게스트 모집 경기" 또는 "동아리전: A vs B" 자동 생성  │
+│     ├── match_id       = matches.id           ← 기존 컬럼 활용              │
+│     └── description    = 모집 정보 요약                                      │
+│                                                                              │
+│  4. matches.schedule_id = 생성된 schedules.id (양방향 참조)                  │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+#### 서비스 로직 (의사코드)
+
+```java
+@Transactional
+public Match confirmRecruitment(UUID recruitmentId) {
+    RecruitmentPost post = recruitmentPostRepository.findById(recruitmentId);
+    post.setStatus(CONFIRMED);
+
+    // 1) matches 생성
+    Match match = Match.builder()
+        .sourceType("RECRUITMENT")
+        .recruitmentId(recruitmentId)
+        .locationId(post.getLocationId())
+        .startAt(post.getStartAt())
+        .endAt(post.getEndAt())
+        .gameFormat(post.getGameFormat())
+        .build();
+    matchRepository.save(match);
+
+    // 2) schedules 생성 (기존 Schedule 엔티티 그대로 활용)
+    Schedule schedule = Schedule.builder()
+        .location(post.getLocation())
+        .scheduleDate(post.getStartAt().toLocalDate())
+        .startTime(post.getStartAt().toLocalTime())
+        .endTime(post.getEndAt().toLocalTime())
+        .status(ScheduleStatus.SCHEDULED)
+        .scheduleType("MATCH")
+        .title("게스트 모집 경기")
+        .matchId(match.getId())
+        .build();
+    scheduleRepository.save(schedule);
+
+    // 3) 양방향 연결
+    match.setScheduleId(schedule.getId());
+
+    // 4) 수락된 신청자 → match_participations
+    ...
+
+    return match;
+}
+```
+
+#### 일정 탭 표시 (기존 API 호환)
+
+```
+GET /api/schedules?startDate=2026-03-20&endDate=2026-03-26
+
+응답 예시:
+[
+  { scheduleType: "REGULAR",  title: "정기 연습",      matchId: null,  ... },
+  { scheduleType: "TRAINING", title: "주간 훈련",      matchId: null,  ... },
+  { scheduleType: "MATCH",    title: "게스트 모집 경기", matchId: "abc", ... },  ← 신규
+  { scheduleType: "MATCH",    title: "동아리전: RIV vs ABC", matchId: "def", ... }  ← 신규
+]
+```
+
+- **기존 ScheduleController, ScheduleResponse 수정 불필요** — `scheduleType`과 `matchId`는 이미 응답에 포함
+- 프론트엔드에서 `scheduleType === 'MATCH'`일 때 매칭 상세 화면으로 연결하는 분기만 추가
+
+#### 장소/시간 중복 체크
+
+```sql
+-- 같은 장소, 같은 날짜에 시간이 겹치는 일정이 있는지 확인
+SELECT COUNT(*) FROM schedules
+WHERE location_id = :locationId
+  AND schedule_date = :date
+  AND status != 'CANCELLED'
+  AND start_time < :endTime
+  AND end_time > :startTime;
+```
+
+- 모집글 생성 시, 매치 확정 시 모두 이 체크 수행
+- 기존 `schedules` 테이블 하나로 일반 일정 + 매칭 일정 통합 관리
+
+#### 변경 영향 범위
+
+| 대상 | 변경 내용 |
+|------|----------|
+| **DB (schedules)** | 변경 없음. `schedule_type`에 'MATCH' 값만 추가 사용, `match_id`는 이미 존재 |
+| **DB (matches)** | `schedule_id` 컬럼 추가 (양방향 참조) |
+| **Schedule.java** | 변경 없음. `scheduleType`은 String, `matchId`는 UUID로 이미 대응 |
+| **ScheduleResponse.java** | 변경 없음. `scheduleType`, `matchId` 이미 응답에 포함 |
+| **ScheduleController** | 변경 없음. 기존 API가 `schedule_type='MATCH'`도 함께 조회 |
+| **프론트엔드 (ScheduleScreen)** | `scheduleType === 'MATCH'` 분기 추가, 매칭 상세 화면 연결 |
+
+### 6.7 포지션 (선택)
 
 ```sql
 -- 포지션 enum 또는 테이블
@@ -530,8 +754,8 @@ CREATE TABLE recruitment_preferred_positions (
 | POST | /api/recruitments/{id}/applications/{userId}/reject | 거절 |
 | POST | /api/recruitments/{id}/confirm | 모집 확정 → matches 생성 |
 | POST | /api/matches/{id}/complete | 경기 완료 처리 |
-| POST | /api/matches/{id}/reviews | 참여자에게 리뷰 |
-| POST | /api/matches/{id}/no-show | 노쇼 신고 |
+| POST | /api/matches/{id}/review | 리뷰 + 노쇼 일괄 제출 (팝업에서 한 번에) |
+| GET | /api/matches/{id}/review-form | 리뷰 팝업용 참가자 목록 (우리팀/상대팀 구분) |
 
 ### 7.2 실제 경기 (matches)
 
@@ -579,7 +803,7 @@ CREATE TABLE recruitment_preferred_positions (
 | 1 | recruitment_posts CRUD | 모집글 생성, 조회 (start_at, end_at) |
 | 2 | 신청/수락/거절 | applications, 진행률 계산 |
 | 3 | 진행률 시각화 | API 응답에 current/needed 포함 |
-| 4 | 확정 → matches 생성 | 목표 인원 충족 시 matches 테이블에 경기 생성 |
+| 4 | 확정 → matches + schedules 생성 | 목표 인원 충족 시 matches + 일정 자동 등록 |
 | 5 | match_participations | 실제 경기 기준 참가 이력 저장 |
 | 6 | 리뷰 기능 | participation_reviews (match 기준) |
 | 7 | 노쇼 신고 | no_show_reports (match_id 기준), users.no_show_count 업데이트 |
@@ -611,8 +835,8 @@ CREATE TABLE recruitment_preferred_positions (
 - [ ] **게스트/번개**: start_at/end_at, 장소(location_id), 인원, 포지션, 경기형태, 마감
 - [ ] **진행률 시각화** (3/6명)
 - [ ] **폼 기반 신청** + 수락/거절
-- [ ] **경기 후 리뷰** (상대에게)
+- [ ] **경기 후 리뷰 팝업** (따봉 👍 방식 + 노쇼 신고 통합, 우리팀/상대팀 구분)
 - [ ] **동아리 친선전**: 5명↑ 모여야 상대 지정, 5:5만
 - [ ] **결과 입력** → 양측 대표 승인 → 관리자 기록
 - [ ] **노쇼 페널티** (모든 경기)
-- [ ] **모집글 ↔ 실제 경기 분리** (확정 시 matches 생성)
+- [ ] **모집글 ↔ 실제 경기 분리** (확정 시 matches 생성 + schedules에 일정 자동 등록)

--- a/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
+++ b/docs/MATCHING_SYSTEM_FEATURE_PLAN.md
@@ -2,7 +2,7 @@
 
 > **작성일**: 2026-03-16  
 > **프로젝트**: 딸바 (PNU Basketball Platform)  
-> **핵심**: 레벨업 시스템, 게스트/번개 모집, 동아리 친선전, 노쇼 페널티
+> **핵심**: EXP 시스템, 게스트/번개 모집, 동아리 친선전, 리뷰 + 노쇼 관리
 
 ---
 
@@ -10,7 +10,7 @@
 
 1. [시스템 개요](#1-시스템-개요)
 2. [공통 요구사항](#2-공통-요구사항)
-3. [게스트/사람 모으기 모집](#3-게스트사람-모으기-모집)
+3. [게스트/번개 모집](#3-게스트번개-모집)
 4. [동아리 친선전](#4-동아리-친선전)
 5. [경기 종료 후 리뷰 + 노쇼 시스템](#5-경기-종료-후-리뷰--노쇼-시스템)
 6. [DB 및 도메인 설계](#6-db-및-도메인-설계)
@@ -25,7 +25,7 @@
 
 | 유형 | 점수 기록 | 경기 형식 | 설명 |
 |------|----------|----------|------|
-| **게스트/사람 모으기** | ❌ (참여 이력만) | 3:3, 4:4, 5:5, 모이는대로 | 번개, 즉석 농구, 결원 보충 |
+| **게스트/번개 모집** | ❌ (참여 이력만) | 3:3, 4:4, 5:5, 모이는대로 | 번개, 즉석 농구, 결원 보충 |
 | **동아리 친선전** | ✅ 상세 기록 | 5:5만 | 팀 대 팀 공식 매치 |
 
 ### 1.2 핵심 가치
@@ -67,7 +67,7 @@
 | 필드 | 타입 | 필수 | 설명 |
 |------|------|------|------|
 | **nickname** | varchar(30) | O | 닉네임 (앱 내 표시명, 모집/리뷰에 노출) |
-| **position** | enum | O | 주 포지션 (GUARD / FORWARD / CENTER) |
+| **position** | enum | O | 주 포지션 1개 (GUARD / FORWARD / CENTER). 추후 보조 포지션 다중 선택 확장 가능 |
 | **exp** | int | O | 경험치 (누적) — DB에는 EXP만 저장 |
 | **no_show_count** | int | O | 노쇼 누적 횟수 |
 | **participation_count** | int | O | 참여 완료 횟수 |
@@ -100,7 +100,7 @@
 
 ---
 
-## 3. 게스트/사람 모으기 모집
+## 3. 게스트/번개 모집
 
 ### 3.1 개요
 
@@ -114,8 +114,8 @@
 | 시작 시각 | start_at | O | 경기 시작 (datetime) |
 | 종료 시각 | end_at | O | 경기 종료 (datetime) — 장소 중복 체크, 일정 표시에 필요 |
 | 장소 | location_id | O | **있는 장소에서 선택** (schedule_locations 참조) |
-| 현재 확정 인원 | int | O | 이미 있는 인원 |
-| 필요한 인원 | int | O | 모집 인원 |
+| 기본 인원 | base_members_count | O | 모집 생성 시점에 이미 확보된 인원 수 |
+| 필요한 인원 | needed_members | O | 추가로 모집할 인원 수 |
 | 포지션 | multi-select | △ | 가드/포워드/센터 우대 |
 | 경기 형태 | enum | O | THREE_VS_THREE, FOUR_VS_FOUR, FIVE_VS_FIVE, FLEXIBLE |
 | 모집 마감 시간 | datetime | △ | 마감 시각 |
@@ -133,7 +133,7 @@
 ```
 
 - 실시간 인원 수 반영
-- 목표 인원 도달 여부는 **상태가 아닌 계산값** (`accepted_count >= needed_members`)
+- 목표 인원 도달 여부는 **상태가 아닌 계산값** (`accepted_count >=needed_members`)
 - "FULL" 뱃지는 UI에서만 표시, DB 상태로 관리하지 않음
 - 모집자가 최종 확정 버튼 → `OPEN` → `CONFIRMED` → matches 생성
 
@@ -177,7 +177,7 @@
 | 장소 | location_id | O | **있는 장소에서 선택** (schedule_locations 참조) |
 | 상대 동아리 | club_id | △ | 지정 시 바로 매칭, 미지정 시 모집 |
 
-### 4.3 펀딩형 출석 조건
+### 4.3 참가 의사 기반 확정 조건
 
 > **같은 동아리 소속인 5명 이상 모여야 상대 동아리로 지정 가능**
 
@@ -251,7 +251,7 @@
 
 **UX 원칙**
 
-- **따봉(👍) 방식**: 점수 X. 좋았으면 👍 누르기 (1), 안 누르면 (0)
+- **따봉(👍) 방식**: 좋았던 참가자에게만 👍를 남기는 방식이며, 별점/비추천 기능은 제공하지 않는다. (row 존재 = 추천, row 없음 = 미평가)
 - **간단함**: 한 화면에서 모든 참가자 한 번에 평가
 - **우리 팀 / 상대 팀** 구분 표시 (한 눈에 보기 쉽게)
 - **노쇼 신고 버튼**: 각 참가자 옆에 "⚠️노쇼" 버튼 (안 나왔으면 누르기)
@@ -306,8 +306,39 @@
 | 기능 | 설명 |
 |------|------|
 | 노쇼 신고 | 리뷰 팝업에서 참가자별 "⚠️노쇼" 버튼 |
-| 노쇼 확인 | 복수 참가자가 같은 사람을 신고 시 자동 확정 (또는 관리자 확인) |
+| 노쇼 확인 | **초기 MVP에서는 자동 확정 없이 관리자 확인 후 반영.** 추후 복수 참가자 신고(2인 이상 또는 과반) 시 자동 확정 후보 분류 도입 |
 | 노쇼 이력 조회 | 사용자별 노쇼 이력 (관리자용) |
+
+> **노쇼 신고 정책**: 노쇼 신고는 경기 종료 후 24시간 이내 가능하며, 동일 경기의 복수 참가자가 동일 사용자를 신고한 경우 자동 확정 후보로 분류한다. 단, 최종 반영은 운영 정책에 따라 관리자 확인 또는 최소 기준 충족 시 자동 확정한다. **초기 MVP에서는 자동 확정 없이 관리자 확인 후 반영한다.**
+
+### 5.3 정책 요약 표
+
+| 항목 | 기한 / 조건 |
+|------|------------|
+| 리뷰 제출 | 경기 종료 후 24시간 이내 |
+| 노쇼 신고 | 경기 종료 후 24시간 이내 |
+| 모집 취소 | 경기 시작 N시간 전까지 (운영 정책에 따라 결정) |
+| 노쇼 확정 (MVP) | 관리자 확인 후 수동 반영 |
+| 노쇼 확정 (추후) | 2인 이상 또는 과반 신고 시 자동 확정 후보 분류 |
+
+### 5.4 경기 완료 처리 권한
+
+`POST /api/matches/{id}/complete` 호출 권한:
+
+| 매칭 유형 | 완료 처리 가능자 |
+|----------|----------------|
+| 게스트/번개 모집 | 모집자 또는 관리자 |
+| 동아리 친선전 | 양팀 대표 중 1인 또는 관리자 |
+
+### 5.5 일정 중복 체크 시점
+
+| 시점 | 검증 내용 |
+|------|----------|
+| 모집 생성 시 | 사용자에게 가능한 슬롯인지 사전 안내 (경고 수준) |
+| 모집 확정 시 | 서버에서 최종 중복 검증 후 match/schedule 생성 |
+| 관리자 일정 생성 시 | 동일 검증 수행 |
+
+> **최종 신뢰는 schedules 기준 서버 검증**이다. 모집 생성 시 안내는 UX 편의를 위한 것이며, 확정 시점에 서버에서 반드시 재검증한다.
 
 ---
 
@@ -345,7 +376,7 @@
 │                                                                                                  │
 │   [기존 컬럼]                      [추가 컬럼]                                                  │
 │   • user_id                        • nickname      VARCHAR(30) UNIQUE                           │
-│   • email                          • position      VARCHAR(20) NOT NULL (GUARD/FORWARD/CENTER)  │
+│   • email                          • position      VARCHAR(20) CHECK (GUARD/FORWARD/CENTER)     │
 │   • real_name                      • exp           INTEGER DEFAULT 0                             │
 │   • real_name                      • no_show_count INTEGER DEFAULT 0                             │
 │   • wins, games, total_score       • participation_count INTEGER DEFAULT 0                      │
@@ -365,7 +396,7 @@
 │         │                                                                                        │
 │         └── (확정 시) matches 생성 ◄── recruitment_posts 또는 club_match_requests                │
 │                   │                                                                              │
-│                   ├── schedules (일정 자동 등록, match_id ↔ schedule_id 양방향)                    │
+│                   ├── schedules (일정 자동 등록, schedules.match_id 단방향 참조)                    │
 │                   ├── match_participations ◄── users (실제 경기 참가 이력)                        │
 │                   │         └── participation_reviews                                            │
 │                   └── no_show_reports (match_id 기준)                                             │
@@ -408,8 +439,8 @@
 1단계: users 확장
    └── V001__add_users_matching_fields.sql
 
-2단계: 모집 관련 ENUM
-   └── recruitment_game_format, recruitment_status
+2단계: 모집/매칭 관련 ENUM
+   └── recruitment_game_format, recruitment_status, application_status, club_match_status
 
 3단계: recruitment_posts, recruitment_applications
    └── V002__create_recruitment_posts.sql
@@ -426,7 +457,7 @@
 ```sql
 -- level 컬럼 없음. exp만 저장. 등급/레벨은 나중에 exp 구간으로 앱에서 계산
 ALTER TABLE users ADD COLUMN IF NOT EXISTS nickname VARCHAR(30) UNIQUE;
-ALTER TABLE users ADD COLUMN IF NOT EXISTS position VARCHAR(20);  -- GUARD, FORWARD, CENTER
+ALTER TABLE users ADD COLUMN IF NOT EXISTS position VARCHAR(20) CHECK (position IN ('GUARD', 'FORWARD', 'CENTER'));
 ALTER TABLE users ADD COLUMN IF NOT EXISTS exp INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS no_show_count INTEGER NOT NULL DEFAULT 0;
 ALTER TABLE users ADD COLUMN IF NOT EXISTS participation_count INTEGER NOT NULL DEFAULT 0;
@@ -446,8 +477,8 @@ CREATE TABLE recruitment_posts (
     start_at        TIMESTAMP NOT NULL,   -- 경기 시작 (datetime) — 장소 중복 체크, 일정 표시에 필요
     end_at          TIMESTAMP NOT NULL,   -- 경기 종료 (datetime)
     location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,  -- 있는 장소에서 선택
-    current_members INTEGER NOT NULL,
-    needed_members INTEGER NOT NULL,
+    base_members_count INTEGER NOT NULL,  -- 모집 생성 시점에 이미 확보된 기본 인원 수. 진행률 = base_members_count + accepted_count
+    needed_members INTEGER NOT NULL,     -- 추가로 모집할 인원 수
     game_format     recruitment_game_format NOT NULL,
     deadline_at     TIMESTAMP,
     status          recruitment_status NOT NULL DEFAULT 'OPEN',
@@ -456,11 +487,13 @@ CREATE TABLE recruitment_posts (
     CONSTRAINT chk_recruitment_time CHECK (start_at < end_at)
 );
 
+CREATE TYPE application_status AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED');
+
 CREATE TABLE recruitment_applications (
     id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     recruitment_id  UUID NOT NULL REFERENCES recruitment_posts(id) ON DELETE CASCADE,
     applicant_id    BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- PENDING, ACCEPTED, REJECTED
+    status          application_status NOT NULL DEFAULT 'PENDING',
     message         VARCHAR(200),
     created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(recruitment_id, applicant_id)
@@ -470,6 +503,14 @@ CREATE TABLE recruitment_applications (
 ### 6.4 동아리 친선전
 
 ```sql
+CREATE TYPE club_match_status AS ENUM ('GATHERING', 'READY', 'MATCHED', 'CONFIRMED', 'DONE', 'CANCELLED');
+-- GATHERING: 홈팀 인원 모집 중
+-- READY:     홈팀 5인 이상 확보, 상대 지정 가능
+-- MATCHED:   상대팀 지정 완료
+-- CONFIRMED: 양팀 5인 이상 확보, 일정 확정
+-- DONE:      경기 종료
+-- CANCELLED: 취소
+
 -- 친선전 신청 (홈팀이 먼저 생성)
 CREATE TABLE club_match_requests (
     id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
@@ -477,13 +518,7 @@ CREATE TABLE club_match_requests (
     start_at        TIMESTAMP NOT NULL,   -- 경기 시작 (datetime)
     end_at          TIMESTAMP NOT NULL,  -- 경기 종료 (datetime)
     location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,  -- 있는 장소에서 선택
-    status          VARCHAR(20) NOT NULL DEFAULT 'GATHERING',
-    -- GATHERING: 홈팀 인원 모집 중
-    -- READY:     홈팀 5인 이상 확보, 상대 지정 가능
-    -- MATCHED:   상대팀 지정 완료
-    -- CONFIRMED: 양팀 5인 이상 확보, 일정 확정
-    -- DONE:      경기 종료
-    -- CANCELLED: 취소
+    status          club_match_status NOT NULL DEFAULT 'GATHERING',
     away_club_id    UUID REFERENCES clubs(id) ON DELETE SET NULL,
     created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
@@ -522,10 +557,9 @@ CREATE TABLE club_match_results (
 -- 실제 확정된 경기 (모집글/동아리전 확정 시 생성)
 CREATE TABLE matches (
     id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-    source_type         VARCHAR(20) NOT NULL,  -- RECRUITMENT, CLUB_MATCH
+    source_type         VARCHAR(20) NOT NULL CHECK (source_type IN ('RECRUITMENT', 'CLUB_MATCH')),
     recruitment_id      UUID REFERENCES recruitment_posts(id) ON DELETE SET NULL,   -- 게스트/번개 확정 시
     club_match_request_id UUID REFERENCES club_match_requests(id) ON DELETE SET NULL,  -- 동아리전 확정 시
-    schedule_id         UUID REFERENCES schedules(id) ON DELETE SET NULL,  -- 일정 연동 (확정 시 자동 생성)
     location_id         UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
     start_at            TIMESTAMP NOT NULL,
     end_at              TIMESTAMP NOT NULL,
@@ -542,26 +576,25 @@ CREATE TABLE matches (
 -- ※ 매치 확정 시 서비스 로직에서 아래를 동시에 수행:
 --   1. matches INSERT
 --   2. schedules INSERT (schedule_type='MATCH', match_id=matches.id)
---   3. matches.schedule_id = 생성된 schedules.id
--- → schedules.match_id ↔ matches.schedule_id 양방향 참조로 일정 탭과 완전 연계
+-- → schedules.match_id 단방향 참조. matches에서 schedule을 찾으려면 schedules.match_id로 역조회
 
 -- 참가 이력 (실제 경기 기준)
 CREATE TABLE match_participations (
     id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     match_id        UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
     user_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    status          VARCHAR(20) NOT NULL,  -- ATTENDED, NO_SHOW
+    status          VARCHAR(20) NOT NULL CHECK (status IN ('ATTENDED', 'NO_SHOW')),
     created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(match_id, user_id)
 );
 
--- 리뷰 (따봉 방식: 1=👍, 0=미평가)
+-- 리뷰 (따봉 방식: 👍를 누른 대상에 대해서만 row 생성)
+-- row 존재 = 추천함, row 없음 = 미평가/추천 안 함
 CREATE TABLE participation_reviews (
     id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
     match_id            UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
     reviewer_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     reviewee_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    thumbs_up           BOOLEAN NOT NULL DEFAULT FALSE,  -- true=👍, false=미평가
     created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     UNIQUE(match_id, reviewer_id, reviewee_id)
 );
@@ -572,7 +605,7 @@ CREATE TABLE no_show_reports (
     match_id        UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
     reporter_id     BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
     reported_user_id BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING',  -- PENDING, CONFIRMED, REJECTED
+    status          VARCHAR(20) NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'CONFIRMED', 'REJECTED')),
     created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 ```
@@ -622,7 +655,6 @@ Schedule.java (현재 구현)
 │  2. matches 테이블에 INSERT                                                 │
 │     ├── source_type, recruitment_id/club_match_request_id                    │
 │     ├── location_id, start_at, end_at, game_format                           │
-│     └── schedule_id (3단계에서 채움)                                         │
 │                                                                              │
 │  3. schedules 테이블에 INSERT (일정 자동 등록)                               │
 │     ├── location_id    = matches.location_id                                 │
@@ -635,7 +667,7 @@ Schedule.java (현재 구현)
 │     ├── match_id       = matches.id           ← 기존 컬럼 활용              │
 │     └── description    = 모집 정보 요약                                      │
 │                                                                              │
-│  4. matches.schedule_id = 생성된 schedules.id (양방향 참조)                  │
+│  ※ matches에서 schedule 조회 시: SELECT * FROM schedules WHERE match_id = :matchId │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -671,10 +703,7 @@ public Match confirmRecruitment(UUID recruitmentId) {
         .build();
     scheduleRepository.save(schedule);
 
-    // 3) 양방향 연결
-    match.setScheduleId(schedule.getId());
-
-    // 4) 수락된 신청자 → match_participations
+    // 3) 수락된 신청자 → match_participations
     ...
 
     return match;
@@ -718,7 +747,7 @@ WHERE location_id = :locationId
 | 대상 | 변경 내용 |
 |------|----------|
 | **DB (schedules)** | 변경 없음. `schedule_type`에 'MATCH' 값만 추가 사용, `match_id`는 이미 존재 |
-| **DB (matches)** | `schedule_id` 컬럼 추가 (양방향 참조) |
+| **DB (matches)** | 변경 없음. schedules.match_id로 단방향 참조 |
 | **Schedule.java** | 변경 없음. `scheduleType`은 String, `matchId`는 UUID로 이미 대응 |
 | **ScheduleResponse.java** | 변경 없음. `scheduleType`, `matchId` 이미 응답에 포함 |
 | **ScheduleController** | 변경 없음. 기존 API가 `schedule_type='MATCH'`도 함께 조회 |
@@ -750,8 +779,8 @@ CREATE TABLE recruitment_preferred_positions (
 | GET | /api/recruitments | 목록 조회 (필터: start_at~end_at, 장소, 경기형태) |
 | GET | /api/recruitments/{id} | 상세 (진행률 포함) |
 | POST | /api/recruitments/{id}/apply | 신청 |
-| POST | /api/recruitments/{id}/applications/{userId}/accept | 수락 |
-| POST | /api/recruitments/{id}/applications/{userId}/reject | 거절 |
+| POST | /api/recruitments/{id}/applications/{applicationId}/accept | 수락 |
+| POST | /api/recruitments/{id}/applications/{applicationId}/reject | 거절 |
 | POST | /api/recruitments/{id}/confirm | 모집 확정 → matches 생성 |
 | POST | /api/matches/{id}/complete | 경기 완료 처리 |
 | POST | /api/matches/{id}/review | 리뷰 + 노쇼 일괄 제출 (팝업에서 한 번에) |
@@ -802,7 +831,7 @@ CREATE TABLE recruitment_preferred_positions (
 |------|------|------|
 | 1 | recruitment_posts CRUD | 모집글 생성, 조회 (start_at, end_at) |
 | 2 | 신청/수락/거절 | applications, 진행률 계산 |
-| 3 | 진행률 시각화 | API 응답에 current/needed 포함 |
+| 3 | 진행률 시각화 | API 응답에 base_members_count + accepted_count / total 포함 |
 | 4 | 확정 → matches + schedules 생성 | 목표 인원 충족 시 matches + 일정 자동 등록 |
 | 5 | match_participations | 실제 경기 기준 참가 이력 저장 |
 | 6 | 리뷰 기능 | participation_reviews (match 기준) |
@@ -835,8 +864,10 @@ CREATE TABLE recruitment_preferred_positions (
 - [ ] **게스트/번개**: start_at/end_at, 장소(location_id), 인원, 포지션, 경기형태, 마감
 - [ ] **진행률 시각화** (3/6명)
 - [ ] **폼 기반 신청** + 수락/거절
-- [ ] **경기 후 리뷰 팝업** (따봉 👍 방식 + 노쇼 신고 통합, 우리팀/상대팀 구분)
+- [ ] **경기 후 리뷰 팝업** (👍 누른 대상만 row 생성 + 노쇼 신고 통합, 우리팀/상대팀 구분)
 - [ ] **동아리 친선전**: 5명↑ 모여야 상대 지정, 5:5만
 - [ ] **결과 입력** → 양측 대표 승인 → 관리자 기록
 - [ ] **노쇼 페널티** (모든 경기)
-- [ ] **모집글 ↔ 실제 경기 분리** (확정 시 matches 생성 + schedules에 일정 자동 등록)
+- [ ] **모집글 ↔ 실제 경기 분리** (확정 시 matches 생성 + schedules에 일정 자동 등록, 단방향 참조)
+- [ ] **정책 표** (리뷰/노쇼 24시간, 모집 취소 기한, 완료 처리 권한)
+- [ ] **일정 중복 체크** (생성 시 안내 + 확정 시 서버 검증)

--- a/docs/database/POSTGRESQL_ENUM_MAPPING.md
+++ b/docs/database/POSTGRESQL_ENUM_MAPPING.md
@@ -1,0 +1,87 @@
+# PostgreSQL Enum 타입 매핑 가이드
+
+## 1. 왜 DB 타입 매칭 오류가 발생하는가?
+
+### 원인
+
+PostgreSQL에는 **네이티브 ENUM 타입**이 있고, JPA/Hibernate의 `@Enumerated(EnumType.STRING)`은 기본적으로 **VARCHAR(문자열)** 로 바인딩합니다.
+
+```
+Hibernate가 보내는 값:  'OPEN' (VARCHAR/character varying)
+PostgreSQL 컬럼 타입:   recruitment_status (ENUM)
+→ 타입 불일치! PostgreSQL은 암시적 변환을 허용하지 않음
+```
+
+### 에러 메시지
+
+```
+ERROR: column "status" is of type recruitment_status but expression is of type character varying
+Hint: You will need to rewrite or cast the expression.
+```
+
+---
+
+## 2. 해결 방법 (두 가지)
+
+### 방법 A: `@JdbcType(PostgreSQLEnumJdbcType.class)` (현재 적용)
+
+Hibernate 6 내장 타입으로, INSERT/UPDATE 시 PostgreSQL enum 타입으로 올바르게 바인딩합니다.
+
+```java
+@Enumerated(EnumType.STRING)
+@JdbcType(PostgreSQLEnumJdbcType.class)
+@Column(name = "status", nullable = false, columnDefinition = "recruitment_status")
+private RecruitmentStatus status;
+```
+
+- **장점**: JPA 레벨에서 명시적, DB 스키마 변경 불필요
+- **필수**: `columnDefinition`에 PostgreSQL enum 타입명 지정
+
+### 방법 B: PostgreSQL implicit cast 등록
+
+DB 마이그레이션에서 VARCHAR → enum 자동 변환을 허용합니다.
+
+```sql
+CREATE TYPE recruitment_status AS ENUM ('OPEN', 'CONFIRMED', 'CLOSED', 'CANCELLED');
+CREATE CAST (character varying AS recruitment_status) WITH INOUT AS IMPLICIT;
+```
+
+- **장점**: `@Enumerated(EnumType.STRING)`만으로 동작
+- **단점**: DB 스키마에 의존, enum 추가 시 cast 재등록 필요
+
+---
+
+## 3. 프로젝트 내 Enum 매핑 현황
+
+| 엔티티 | 필드 | DB 컬럼 타입 | JPA 매핑 | 상태 |
+|--------|------|--------------|----------|------|
+| **RecruitmentPost** | gameFormat | recruitment_game_format | @JdbcType | ✅ 수정됨 |
+| **RecruitmentPost** | status | recruitment_status | @JdbcType | ✅ 수정됨 |
+| **RecruitmentApplication** | status | application_status | @JdbcType | ✅ 수정됨 |
+| **ClubMatchRequest** | status | club_match_status | @JdbcType | ✅ 수정됨 |
+| **Match** | gameFormat | recruitment_game_format | @JdbcType | ✅ 수정됨 |
+| **Match** | sourceType | VARCHAR(20) CHECK | @Enumerated | ✅ 문제없음 |
+| **ClubMember** | role | club_role | @Enumerated | ✅ implicit cast 있음 |
+| **Schedule** | status | schedule_status | @Enumerated | ✅ implicit cast 있음 |
+| **User** | loginType | VARCHAR(20) | @Enumerated | ✅ 문제없음 |
+| **User** | position | VARCHAR(20) CHECK | @Enumerated | ✅ 문제없음 |
+| **MatchParticipation** | status | VARCHAR(20) CHECK | @Enumerated | ✅ 문제없음 |
+| **NoShowReport** | status | VARCHAR(20) CHECK | @Enumerated | ✅ 문제없음 |
+
+---
+
+## 4. 새 PostgreSQL enum 추가 시 체크리스트
+
+1. **마이그레이션**에 `CREATE TYPE ... AS ENUM (...)` 추가
+2. **엔티티**에 `@JdbcType(PostgreSQLEnumJdbcType.class)` + `columnDefinition = "enum_type_name"` 추가
+3. **또는** implicit cast 등록: `CREATE CAST (character varying AS enum_type) WITH INOUT AS IMPLICIT`
+
+---
+
+## 5. 참고: VARCHAR vs ENUM
+
+| DB 컬럼 정의 | Hibernate @Enumerated(STRING) | 동작 |
+|-------------|------------------------------|------|
+| `VARCHAR(20)` | ✅ | 정상 (문자열로 저장) |
+| `VARCHAR(20) CHECK (x IN (...))` | ✅ | 정상 |
+| `custom_enum` (PostgreSQL ENUM) | ❌ | **타입 불일치** → @JdbcType 필요 |

--- a/docs/database/migrations/add_club_match_requests.sql
+++ b/docs/database/migrations/add_club_match_requests.sql
@@ -1,0 +1,47 @@
+-- 매칭 시스템 Phase 3: 동아리 친선전 테이블
+
+CREATE TYPE club_match_status AS ENUM ('GATHERING', 'READY', 'MATCHED', 'CONFIRMED', 'DONE', 'CANCELLED');
+
+CREATE TABLE club_match_requests (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    home_club_id    UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    start_at        TIMESTAMP NOT NULL,
+    end_at          TIMESTAMP NOT NULL,
+    location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
+    status          club_match_status NOT NULL DEFAULT 'GATHERING',
+    away_club_id    UUID REFERENCES clubs(id) ON DELETE SET NULL,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_club_match_request_time CHECK (start_at < end_at)
+);
+
+CREATE INDEX idx_club_match_requests_home ON club_match_requests(home_club_id);
+CREATE INDEX idx_club_match_requests_away ON club_match_requests(away_club_id) WHERE away_club_id IS NOT NULL;
+CREATE INDEX idx_club_match_requests_status ON club_match_requests(status);
+
+CREATE TABLE club_match_attendances (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    request_id      UUID NOT NULL REFERENCES club_match_requests(id) ON DELETE CASCADE,
+    club_id         UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    user_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(request_id, club_id, user_id)
+);
+
+CREATE INDEX idx_club_match_attendances_request ON club_match_attendances(request_id);
+
+CREATE TABLE club_match_results (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    request_id      UUID NOT NULL REFERENCES club_match_requests(id) ON DELETE CASCADE UNIQUE,
+    home_score      INTEGER NOT NULL,
+    away_score      INTEGER NOT NULL,
+    home_approved   BOOLEAN NOT NULL DEFAULT FALSE,
+    away_approved   BOOLEAN NOT NULL DEFAULT FALSE,
+    admin_approved  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- matches 테이블에 club_match_request_id FK 추가 (Phase 2에서 생성된 테이블)
+ALTER TABLE matches ADD CONSTRAINT fk_matches_club_match_request
+    FOREIGN KEY (club_match_request_id) REFERENCES club_match_requests(id) ON DELETE SET NULL;

--- a/docs/database/migrations/add_club_wins_and_matches.sql
+++ b/docs/database/migrations/add_club_wins_and_matches.sql
@@ -1,0 +1,6 @@
+-- clubs 테이블에 wins 컬럼 추가 (동아리전 승리 수)
+-- 매칭 확정 시 winner_club_id 기준으로 clubs.wins를 갱신하는 로직은 애플리케이션에서 처리
+-- club_matches 테이블은 schemas/06_club_matches.sql 참고 (schedules 존재 시 별도 실행)
+
+ALTER TABLE clubs ADD COLUMN IF NOT EXISTS wins INTEGER NOT NULL DEFAULT 0;
+CREATE INDEX IF NOT EXISTS idx_clubs_wins ON clubs(wins DESC);

--- a/docs/database/migrations/add_matches_and_participations.sql
+++ b/docs/database/migrations/add_matches_and_participations.sql
@@ -1,0 +1,53 @@
+-- 매칭 시스템 Phase 2: matches + 참가 이력 테이블
+
+CREATE TABLE matches (
+    id                      UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    source_type             VARCHAR(20) NOT NULL CHECK (source_type IN ('RECRUITMENT', 'CLUB_MATCH')),
+    recruitment_id          UUID REFERENCES recruitment_posts(id) ON DELETE SET NULL,
+    club_match_request_id   UUID,  -- Phase 3에서 FK 추가
+    location_id             UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
+    start_at                TIMESTAMP NOT NULL,
+    end_at                  TIMESTAMP NOT NULL,
+    game_format             recruitment_game_format,
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_match_time CHECK (start_at < end_at),
+    CONSTRAINT chk_match_source CHECK (
+        (source_type = 'RECRUITMENT' AND recruitment_id IS NOT NULL AND club_match_request_id IS NULL) OR
+        (source_type = 'CLUB_MATCH' AND club_match_request_id IS NOT NULL AND recruitment_id IS NULL)
+    )
+);
+
+CREATE INDEX idx_matches_source ON matches(source_type);
+CREATE INDEX idx_matches_recruitment ON matches(recruitment_id) WHERE recruitment_id IS NOT NULL;
+CREATE INDEX idx_matches_start_at ON matches(start_at);
+
+CREATE TABLE match_participations (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    match_id        UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    user_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status          VARCHAR(20) NOT NULL CHECK (status IN ('ATTENDED', 'NO_SHOW')),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(match_id, user_id)
+);
+
+CREATE INDEX idx_match_participations_match ON match_participations(match_id);
+CREATE INDEX idx_match_participations_user ON match_participations(user_id);
+
+CREATE TABLE participation_reviews (
+    id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    match_id            UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    reviewer_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    reviewee_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(match_id, reviewer_id, reviewee_id)
+);
+
+CREATE TABLE no_show_reports (
+    id                  UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    match_id            UUID NOT NULL REFERENCES matches(id) ON DELETE CASCADE,
+    reporter_id         BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    reported_user_id    BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status              VARCHAR(20) NOT NULL DEFAULT 'PENDING' CHECK (status IN ('PENDING', 'CONFIRMED', 'REJECTED')),
+    created_at          TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);

--- a/docs/database/migrations/add_recruitment_posts.sql
+++ b/docs/database/migrations/add_recruitment_posts.sql
@@ -1,0 +1,39 @@
+-- 매칭 시스템 Phase 2: 게스트/번개 모집 테이블
+
+CREATE TYPE recruitment_game_format AS ENUM ('THREE_VS_THREE', 'FOUR_VS_FOUR', 'FIVE_VS_FIVE', 'FLEXIBLE');
+CREATE TYPE recruitment_status AS ENUM ('OPEN', 'CONFIRMED', 'CLOSED', 'CANCELLED');
+CREATE TYPE application_status AS ENUM ('PENDING', 'ACCEPTED', 'REJECTED');
+
+CREATE TABLE recruitment_posts (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    author_id       BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    start_at        TIMESTAMP NOT NULL,
+    end_at          TIMESTAMP NOT NULL,
+    location_id     UUID NOT NULL REFERENCES schedule_locations(id) ON DELETE RESTRICT,
+    base_members_count INTEGER NOT NULL,
+    needed_members  INTEGER NOT NULL,
+    game_format     recruitment_game_format NOT NULL,
+    deadline_at     TIMESTAMP,
+    status          recruitment_status NOT NULL DEFAULT 'OPEN',
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_recruitment_time CHECK (start_at < end_at)
+);
+
+CREATE INDEX idx_recruitment_posts_author ON recruitment_posts(author_id);
+CREATE INDEX idx_recruitment_posts_status ON recruitment_posts(status);
+CREATE INDEX idx_recruitment_posts_start_at ON recruitment_posts(start_at);
+CREATE INDEX idx_recruitment_posts_location ON recruitment_posts(location_id);
+
+CREATE TABLE recruitment_applications (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    recruitment_id  UUID NOT NULL REFERENCES recruitment_posts(id) ON DELETE CASCADE,
+    applicant_id    BIGINT NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+    status          application_status NOT NULL DEFAULT 'PENDING',
+    message         VARCHAR(200),
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(recruitment_id, applicant_id)
+);
+
+CREATE INDEX idx_recruitment_applications_recruitment ON recruitment_applications(recruitment_id);
+CREATE INDEX idx_recruitment_applications_applicant ON recruitment_applications(applicant_id);

--- a/docs/database/migrations/add_users_matching_fields.sql
+++ b/docs/database/migrations/add_users_matching_fields.sql
@@ -1,0 +1,10 @@
+-- 매칭 시스템 Phase 1: users 테이블 확장
+-- nickname, position, exp, no_show_count, participation_count 추가
+
+ALTER TABLE users ADD COLUMN IF NOT EXISTS nickname VARCHAR(30) UNIQUE;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS position VARCHAR(20) CHECK (position IN ('GUARD', 'FORWARD', 'CENTER'));
+ALTER TABLE users ADD COLUMN IF NOT EXISTS exp INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS no_show_count INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE users ADD COLUMN IF NOT EXISTS participation_count INTEGER NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS idx_users_nickname ON users(nickname);

--- a/docs/database/schema.sql
+++ b/docs/database/schema.sql
@@ -62,11 +62,13 @@ CREATE TABLE clubs (
     logo_url      VARCHAR(500),
     introduction  TEXT,
     captain_id    BIGINT REFERENCES users(user_id) ON DELETE SET NULL,
+    wins          INTEGER NOT NULL DEFAULT 0,
     created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX idx_clubs_captain_id ON clubs(captain_id);
 CREATE INDEX idx_clubs_name ON clubs(name);
+CREATE INDEX idx_clubs_wins ON clubs(wins DESC);
 
 -- ============================================================
 -- club_members (1 user : 1 club)

--- a/docs/database/schema.sql
+++ b/docs/database/schema.sql
@@ -37,14 +37,18 @@ CREATE TABLE users (
     kakao_id                VARCHAR(255) UNIQUE,
     date_of_birth           DATE,
     is_pnu_student          BOOLEAN NOT NULL DEFAULT false,
-    is_admin                BOOLEAN NOT NULL DEFAULT false,
     department              VARCHAR(100),
     student_id              VARCHAR(20),
     wins                    INTEGER NOT NULL DEFAULT 0,
     games                   INTEGER NOT NULL DEFAULT 0,
     total_score             INTEGER NOT NULL DEFAULT 0,
     virtual_currency        INTEGER NOT NULL DEFAULT 0,
-    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    nickname                VARCHAR(30) UNIQUE,
+    position                VARCHAR(20) CHECK (position IN ('GUARD', 'FORWARD', 'CENTER')),
+    exp                     INTEGER NOT NULL DEFAULT 0,
+    no_show_count           INTEGER NOT NULL DEFAULT 0,
+    participation_count     INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE UNIQUE INDEX idx_users_student_id_unique ON users(student_id) WHERE student_id IS NOT NULL AND student_id != '';
@@ -52,6 +56,7 @@ CREATE INDEX idx_users_email ON users(email);
 CREATE INDEX idx_users_google_id ON users(google_id);
 CREATE INDEX idx_users_kakao_id ON users(kakao_id);
 CREATE INDEX idx_users_real_name ON users(real_name);
+CREATE INDEX idx_users_nickname ON users(nickname);
 
 -- ============================================================
 -- clubs

--- a/docs/database/schemas/01_users.sql
+++ b/docs/database/schemas/01_users.sql
@@ -21,7 +21,12 @@ CREATE TABLE users (
     games                   INTEGER NOT NULL DEFAULT 0,
     total_score             INTEGER NOT NULL DEFAULT 0,
     virtual_currency        INTEGER NOT NULL DEFAULT 0,
-    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+    created_at              TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    nickname                VARCHAR(30) UNIQUE,
+    position                VARCHAR(20) CHECK (position IN ('GUARD', 'FORWARD', 'CENTER')),
+    exp                     INTEGER NOT NULL DEFAULT 0,
+    no_show_count           INTEGER NOT NULL DEFAULT 0,
+    participation_count     INTEGER NOT NULL DEFAULT 0
 );
 
 CREATE UNIQUE INDEX idx_users_student_id_unique ON users(student_id) WHERE student_id IS NOT NULL AND student_id != '';
@@ -29,3 +34,4 @@ CREATE INDEX idx_users_email ON users(email);
 CREATE INDEX idx_users_google_id ON users(google_id);
 CREATE INDEX idx_users_kakao_id ON users(kakao_id);
 CREATE INDEX idx_users_real_name ON users(real_name);
+CREATE INDEX idx_users_nickname ON users(nickname);

--- a/docs/database/schemas/02_clubs.sql
+++ b/docs/database/schemas/02_clubs.sql
@@ -8,11 +8,13 @@ CREATE TABLE clubs (
     logo_url      VARCHAR(500),
     introduction  TEXT,
     captain_id    BIGINT REFERENCES users(user_id) ON DELETE SET NULL,
+    wins          INTEGER NOT NULL DEFAULT 0,
     created_at    TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
 CREATE INDEX idx_clubs_captain_id ON clubs(captain_id);
 CREATE INDEX idx_clubs_name ON clubs(name);
+CREATE INDEX idx_clubs_wins ON clubs(wins DESC);
 
 -- ============================================================
 -- club_members (1 user : 1 club)

--- a/docs/database/schemas/06_club_matches.sql
+++ b/docs/database/schemas/06_club_matches.sql
@@ -1,0 +1,25 @@
+-- ============================================================
+-- club_matches (동아리전 매칭 - 가정)
+-- schedules.match_id와 연동하여 동아리전 결과를 기록
+-- ============================================================
+CREATE TABLE IF NOT EXISTS club_matches (
+    id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    schedule_id     UUID REFERENCES schedules(id) ON DELETE SET NULL,
+    home_club_id    UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    away_club_id    UUID NOT NULL REFERENCES clubs(id) ON DELETE CASCADE,
+    home_score      INTEGER NOT NULL DEFAULT 0,
+    away_score      INTEGER NOT NULL DEFAULT 0,
+    winner_club_id  UUID REFERENCES clubs(id) ON DELETE SET NULL,
+    match_date      DATE NOT NULL,
+    status          VARCHAR(20) NOT NULL DEFAULT 'COMPLETED',
+    created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT chk_club_matches_different_clubs CHECK (home_club_id != away_club_id)
+);
+
+CREATE INDEX idx_club_matches_home_club ON club_matches(home_club_id);
+CREATE INDEX idx_club_matches_away_club ON club_matches(away_club_id);
+CREATE INDEX idx_club_matches_winner ON club_matches(winner_club_id);
+CREATE INDEX idx_club_matches_date ON club_matches(match_date);
+
+COMMENT ON TABLE club_matches IS '동아리전 매칭 결과 (승리 시 clubs.wins 업데이트)';

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -4,11 +4,17 @@ import 'core/theme/app_theme.dart';
 import 'presentation/providers/auth_provider.dart';
 import 'presentation/providers/community_provider.dart';
 import 'presentation/providers/schedule_provider.dart';
+import 'presentation/providers/recruitment_provider.dart';
+import 'presentation/providers/match_provider.dart';
+import 'presentation/providers/club_match_provider.dart';
 import 'presentation/screens/auth/login_screen.dart';
 import 'presentation/screens/auth/complete_profile_screen.dart';
 import 'presentation/screens/auth/club_selection_screen.dart';
-import 'presentation/screens/user/user_tab.dart';
 import 'presentation/screens/root/root_screen.dart';
+import 'presentation/screens/matching/recruitment_create_screen.dart';
+import 'presentation/screens/matching/recruitment_detail_screen.dart';
+import 'presentation/screens/matching/club_match_create_screen.dart';
+import 'presentation/screens/matching/club_match_detail_screen.dart';
 
 class BasketballApp extends StatelessWidget {
   const BasketballApp({super.key});
@@ -20,11 +26,30 @@ class BasketballApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => AuthProvider()),
         ChangeNotifierProvider(create: (_) => CommunityProvider()),
         ChangeNotifierProvider(create: (_) => ScheduleProvider()),
+        ChangeNotifierProvider(create: (_) => RecruitmentProvider()),
+        ChangeNotifierProvider(create: (_) => MatchProvider()),
+        ChangeNotifierProvider(create: (_) => ClubMatchProvider()),
       ],
       child: MaterialApp(
         title: '딸바',
         theme: AppTheme.theme,
-        home: const RootScreen(initialIndex: 1),
+        home: const RootScreen(initialIndex: 0),
+        onGenerateRoute: (settings) {
+          switch (settings.name) {
+            case '/recruitment-detail':
+              final id = settings.arguments as String;
+              return MaterialPageRoute(
+                builder: (_) => RecruitmentDetailScreen(recruitmentId: id),
+              );
+            case '/club-match-detail':
+              final id = settings.arguments as String;
+              return MaterialPageRoute(
+                builder: (_) => ClubMatchDetailScreen(requestId: id),
+              );
+            default:
+              return null;
+          }
+        },
         routes: {
           '/login': (context) => const LoginScreen(),
           '/home': (context) => const RootScreen(),
@@ -32,12 +57,14 @@ class BasketballApp extends StatelessWidget {
           '/root': (context) => const RootScreen(),
           '/complete-profile': (context) => const CompleteProfileScreen(),
           '/club-selection': (context) => const ClubSelectionScreen(),
+          '/recruitment-create': (context) => const RecruitmentCreateScreen(),
+          '/club-match-create': (context) => const ClubMatchCreateScreen(),
         },
       ),
     );
   }
 }
-//login했는지 확인하는 Gate 토큰 확인시 메인화면/확인불가시 로그인화면
+
 class AuthGate extends StatefulWidget {
   const AuthGate({super.key});
 

--- a/frontend/lib/app.dart
+++ b/frontend/lib/app.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'core/theme/app_theme.dart';
+import 'core/auth/session_expired_handler.dart';
 import 'presentation/providers/auth_provider.dart';
 import 'presentation/providers/community_provider.dart';
 import 'presentation/providers/schedule_provider.dart';
@@ -16,8 +17,32 @@ import 'presentation/screens/matching/recruitment_detail_screen.dart';
 import 'presentation/screens/matching/club_match_create_screen.dart';
 import 'presentation/screens/matching/club_match_detail_screen.dart';
 
-class BasketballApp extends StatelessWidget {
+class BasketballApp extends StatefulWidget {
   const BasketballApp({super.key});
+
+  @override
+  State<BasketballApp> createState() => _BasketballAppState();
+}
+
+class _BasketballAppState extends State<BasketballApp> {
+  final GlobalKey<NavigatorState> _navigatorKey = GlobalKey<NavigatorState>();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _configureSessionExpiredHandler();
+    });
+  }
+
+  void _configureSessionExpiredHandler() {
+    final ctx = _navigatorKey.currentContext;
+    if (ctx == null) return;
+    SessionExpiredHandler.configure(
+      navigatorKey: _navigatorKey,
+      onLogout: () => ctx.read<AuthProvider>().logout(),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,9 +56,10 @@ class BasketballApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => ClubMatchProvider()),
       ],
       child: MaterialApp(
+        navigatorKey: _navigatorKey,
         title: '딸바',
         theme: AppTheme.theme,
-        home: const RootScreen(initialIndex: 0),
+        home: const AuthGate(),
         onGenerateRoute: (settings) {
           switch (settings.name) {
             case '/recruitment-detail':

--- a/frontend/lib/core/auth/session_expired_handler.dart
+++ b/frontend/lib/core/auth/session_expired_handler.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+
+/// 401(Unauthorized) 발생 시 로그인 만료 처리
+class SessionExpiredHandler {
+  static GlobalKey<NavigatorState>? _navigatorKey;
+  static Future<void> Function()? _onLogout;
+
+  /// 앱 시작 시 설정 (navigatorKey, 로그아웃 콜백)
+  static void configure({
+    required GlobalKey<NavigatorState> navigatorKey,
+    required Future<void> Function() onLogout,
+  }) {
+    _navigatorKey = navigatorKey;
+    _onLogout = onLogout;
+  }
+
+  /// 401 발생 시 호출: 로그아웃 후 로그인 화면으로 이동
+  static void trigger() {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      final ctx = _navigatorKey?.currentContext;
+      if (ctx == null) return;
+
+      try {
+        await _onLogout?.call();
+      } catch (_) {}
+
+      if (!ctx.mounted) return;
+      ScaffoldMessenger.of(ctx).showSnackBar(
+        const SnackBar(
+          content: Text('로그인이 만료되었습니다.'),
+          backgroundColor: Colors.red,
+        ),
+      );
+
+      if (!ctx.mounted) return;
+      Navigator.of(ctx).pushNamedAndRemoveUntil('/login', (route) => false);
+    });
+  }
+}

--- a/frontend/lib/core/constants/api_endpoints.dart
+++ b/frontend/lib/core/constants/api_endpoints.dart
@@ -44,4 +44,31 @@ class ApiEndpoints {
   static const String schedules = '/api/schedules';
   static const String scheduleLocations = '/api/schedules/locations';
   static String schedule(String id) => '/api/schedules/$id';
+
+  // Recruitment endpoints
+  static const String recruitments = '/api/recruitments';
+  static String recruitment(String id) => '/api/recruitments/$id';
+  static String recruitmentApply(String id) => '/api/recruitments/$id/apply';
+  static String recruitmentApplicationAccept(String id, String applicationId) =>
+      '/api/recruitments/$id/applications/$applicationId/accept';
+  static String recruitmentApplicationReject(String id, String applicationId) =>
+      '/api/recruitments/$id/applications/$applicationId/reject';
+  static String recruitmentConfirm(String id) => '/api/recruitments/$id/confirm';
+  static String recruitmentCancel(String id) => '/api/recruitments/$id/cancel';
+
+  // Match endpoints
+  static const String matches = '/api/matches';
+  static String match(String id) => '/api/matches/$id';
+  static String matchComplete(String id) => '/api/matches/$id/complete';
+  static String matchReviewForm(String id) => '/api/matches/$id/review-form';
+  static String matchReview(String id) => '/api/matches/$id/review';
+
+  // Club Match endpoints
+  static const String clubMatchRequests = '/api/club-matches/requests';
+  static String clubMatchRequest(String id) => '/api/club-matches/requests/$id';
+  static String clubMatchAttend(String id) => '/api/club-matches/requests/$id/attend';
+  static String clubMatchMatch(String id) => '/api/club-matches/requests/$id/match';
+  static String clubMatchResult(String id) => '/api/club-matches/requests/$id/result';
+  static String clubMatchApproveResult(String id) =>
+      '/api/club-matches/requests/$id/approve-result';
 }

--- a/frontend/lib/core/utils/error_message_util.dart
+++ b/frontend/lib/core/utils/error_message_util.dart
@@ -12,7 +12,7 @@ String toUserFriendlyMessage(Object e) {
       msg.contains('timeoutexception') ||
       msg.contains('connection timed out') ||
       msg.contains('network is unreachable');
-  return isNetworkError
-      ? networkErrorMessage
-      : e.toString().replaceFirst('Exception: ', '');
+  if (isNetworkError) return networkErrorMessage;
+  if (e is FormatException) return '날짜 형식이 올바르지 않습니다';
+  return e.toString().replaceFirst('Exception: ', '');
 }

--- a/frontend/lib/data/models/club_match_model.dart
+++ b/frontend/lib/data/models/club_match_model.dart
@@ -1,0 +1,112 @@
+class ClubMatchRequestModel {
+  final String id;
+  final String homeClubId;
+  final String homeClubName;
+  final String? awayClubId;
+  final String? awayClubName;
+  final DateTime startAt;
+  final DateTime endAt;
+  final String locationName;
+  final String status;
+  final int homeAttendanceCount;
+  final int awayAttendanceCount;
+  final DateTime createdAt;
+
+  ClubMatchRequestModel({
+    required this.id,
+    required this.homeClubId,
+    required this.homeClubName,
+    this.awayClubId,
+    this.awayClubName,
+    required this.startAt,
+    required this.endAt,
+    required this.locationName,
+    required this.status,
+    required this.homeAttendanceCount,
+    required this.awayAttendanceCount,
+    required this.createdAt,
+  });
+
+  factory ClubMatchRequestModel.fromJson(Map<String, dynamic> json) {
+    return ClubMatchRequestModel(
+      id: json['id']?.toString() ?? '',
+      homeClubId: json['homeClubId']?.toString() ?? '',
+      homeClubName: json['homeClubName'] as String? ?? '',
+      awayClubId: json['awayClubId']?.toString(),
+      awayClubName: json['awayClubName'] as String?,
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: DateTime.parse(json['endAt'] as String),
+      locationName: json['locationName'] as String? ?? '',
+      status: json['status'] as String? ?? 'GATHERING',
+      homeAttendanceCount: (json['homeAttendanceCount'] as num?)?.toInt() ?? 0,
+      awayAttendanceCount: (json['awayAttendanceCount'] as num?)?.toInt() ?? 0,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  String get statusDisplay {
+    switch (status) {
+      case 'GATHERING':
+        return '모집중';
+      case 'READY':
+        return '준비완료';
+      case 'MATCHED':
+        return '매칭완료';
+      case 'CONFIRMED':
+        return '확정';
+      case 'DONE':
+        return '완료';
+      case 'CANCELLED':
+        return '취소';
+      default:
+        return status;
+    }
+  }
+
+  bool get hasAway => awayClubId != null && awayClubName != null;
+  bool get isGathering => status == 'GATHERING';
+  bool get isReady => status == 'READY';
+  bool get isMatched => status == 'MATCHED';
+  bool get isConfirmed => status == 'CONFIRMED';
+  bool get isDone => status == 'DONE';
+}
+
+class ClubMatchResultModel {
+  final String id;
+  final String requestId;
+  final String homeClubName;
+  final String awayClubName;
+  final int homeScore;
+  final int awayScore;
+  final bool homeApproved;
+  final bool awayApproved;
+  final bool adminApproved;
+
+  ClubMatchResultModel({
+    required this.id,
+    required this.requestId,
+    required this.homeClubName,
+    required this.awayClubName,
+    required this.homeScore,
+    required this.awayScore,
+    required this.homeApproved,
+    required this.awayApproved,
+    required this.adminApproved,
+  });
+
+  factory ClubMatchResultModel.fromJson(Map<String, dynamic> json) {
+    return ClubMatchResultModel(
+      id: json['id']?.toString() ?? '',
+      requestId: json['requestId']?.toString() ?? '',
+      homeClubName: json['homeClubName'] as String? ?? '',
+      awayClubName: json['awayClubName'] as String? ?? '',
+      homeScore: (json['homeScore'] as num?)?.toInt() ?? 0,
+      awayScore: (json['awayScore'] as num?)?.toInt() ?? 0,
+      homeApproved: json['homeApproved'] as bool? ?? false,
+      awayApproved: json['awayApproved'] as bool? ?? false,
+      adminApproved: json['adminApproved'] as bool? ?? false,
+    );
+  }
+
+  bool get isFullyApproved => homeApproved && awayApproved;
+}

--- a/frontend/lib/data/models/club_model.dart
+++ b/frontend/lib/data/models/club_model.dart
@@ -20,6 +20,8 @@ class ClubModel {
   final String? captainName;
   final String? captainProfileImageUrl;
   final bool? isCaptain;
+  final int wins;
+  final int rank;
 
   ClubModel({
     required this.clubId,
@@ -30,6 +32,8 @@ class ClubModel {
     this.captainName,
     this.captainProfileImageUrl,
     this.isCaptain,
+    this.wins = 0,
+    this.rank = 0,
   });
 
   ClubModel copyWith({
@@ -41,6 +45,8 @@ class ClubModel {
     String? captainName,
     String? captainProfileImageUrl,
     bool? isCaptain,
+    int? wins,
+    int? rank,
   }) {
     return ClubModel(
       clubId: clubId ?? this.clubId,
@@ -51,6 +57,8 @@ class ClubModel {
       captainName: captainName ?? this.captainName,
       captainProfileImageUrl: captainProfileImageUrl ?? this.captainProfileImageUrl,
       isCaptain: isCaptain ?? this.isCaptain,
+      wins: wins ?? this.wins,
+      rank: rank ?? this.rank,
     );
   }
 

--- a/frontend/lib/data/models/match_model.dart
+++ b/frontend/lib/data/models/match_model.dart
@@ -1,0 +1,121 @@
+class MatchModel {
+  final String id;
+  final String sourceType;
+  final String? recruitmentId;
+  final String locationName;
+  final DateTime startAt;
+  final DateTime endAt;
+  final String? gameFormat;
+  final DateTime createdAt;
+
+  MatchModel({
+    required this.id,
+    required this.sourceType,
+    this.recruitmentId,
+    required this.locationName,
+    required this.startAt,
+    required this.endAt,
+    this.gameFormat,
+    required this.createdAt,
+  });
+
+  factory MatchModel.fromJson(Map<String, dynamic> json) {
+    return MatchModel(
+      id: json['id']?.toString() ?? '',
+      sourceType: json['sourceType'] as String? ?? '',
+      recruitmentId: json['recruitmentId']?.toString(),
+      locationName: json['locationName'] as String? ?? '',
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: DateTime.parse(json['endAt'] as String),
+      gameFormat: json['gameFormat'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  bool get isRecruitment => sourceType == 'RECRUITMENT';
+  bool get isClubMatch => sourceType == 'CLUB_MATCH';
+  bool get isEnded => DateTime.now().isAfter(endAt);
+
+  String get gameFormatDisplay {
+    switch (gameFormat) {
+      case 'THREE_VS_THREE':
+        return '3:3';
+      case 'FOUR_VS_FOUR':
+        return '4:4';
+      case 'FIVE_VS_FIVE':
+        return '5:5';
+      case 'FLEXIBLE':
+        return '자유';
+      default:
+        return gameFormat ?? '5:5';
+    }
+  }
+}
+
+class ReviewFormModel {
+  final String matchId;
+  final DateTime startAt;
+  final DateTime endAt;
+  final String locationName;
+  final bool alreadySubmitted;
+  final List<ParticipantModel> participants;
+
+  ReviewFormModel({
+    required this.matchId,
+    required this.startAt,
+    required this.endAt,
+    required this.locationName,
+    required this.alreadySubmitted,
+    required this.participants,
+  });
+
+  factory ReviewFormModel.fromJson(Map<String, dynamic> json) {
+    final list = json['participants'] as List<dynamic>? ?? [];
+    return ReviewFormModel(
+      matchId: json['matchId']?.toString() ?? '',
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: DateTime.parse(json['endAt'] as String),
+      locationName: json['locationName'] as String? ?? '',
+      alreadySubmitted: json['alreadySubmitted'] as bool? ?? false,
+      participants: list
+          .map((e) => ParticipantModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+}
+
+class ParticipantModel {
+  final int userId;
+  final String nickname;
+  final String? position;
+  final int exp;
+
+  ParticipantModel({
+    required this.userId,
+    required this.nickname,
+    this.position,
+    required this.exp,
+  });
+
+  factory ParticipantModel.fromJson(Map<String, dynamic> json) {
+    return ParticipantModel(
+      userId: (json['userId'] as num?)?.toInt() ?? 0,
+      nickname: json['nickname'] as String? ?? '',
+      position: json['position'] as String?,
+      exp: (json['exp'] as num?)?.toInt() ?? 0,
+    );
+  }
+
+  String get positionDisplay {
+    switch (position) {
+      case 'GUARD':
+        return '가드';
+      case 'FORWARD':
+        return '포워드';
+      case 'CENTER':
+        return '센터';
+      default:
+        return position ?? '';
+    }
+  }
+}

--- a/frontend/lib/data/models/recruitment_model.dart
+++ b/frontend/lib/data/models/recruitment_model.dart
@@ -1,0 +1,248 @@
+class RecruitmentListModel {
+  final String id;
+  final String authorNickname;
+  final DateTime startAt;
+  final DateTime endAt;
+  final String locationName;
+  final int baseMembersCount;
+  final int neededMembers;
+  final int acceptedCount;
+  final String gameFormat;
+  final String status;
+  final DateTime? deadlineAt;
+  final DateTime createdAt;
+  final bool isFull;
+
+  RecruitmentListModel({
+    required this.id,
+    required this.authorNickname,
+    required this.startAt,
+    required this.endAt,
+    required this.locationName,
+    required this.baseMembersCount,
+    required this.neededMembers,
+    required this.acceptedCount,
+    required this.gameFormat,
+    required this.status,
+    this.deadlineAt,
+    required this.createdAt,
+    required this.isFull,
+  });
+
+  factory RecruitmentListModel.fromJson(Map<String, dynamic> json) {
+    return RecruitmentListModel(
+      id: json['id']?.toString() ?? '',
+      authorNickname: json['authorNickname'] as String? ?? '',
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: DateTime.parse(json['endAt'] as String),
+      locationName: json['locationName'] as String? ?? '',
+      baseMembersCount: (json['baseMembersCount'] as num?)?.toInt() ?? 0,
+      neededMembers: (json['neededMembers'] as num?)?.toInt() ?? 0,
+      acceptedCount: (json['acceptedCount'] as num?)?.toInt() ?? 0,
+      gameFormat: json['gameFormat'] as String? ?? 'FLEXIBLE',
+      status: json['status'] as String? ?? 'OPEN',
+      deadlineAt: json['deadlineAt'] != null
+          ? DateTime.parse(json['deadlineAt'] as String)
+          : null,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      isFull: json['isFull'] as bool? ?? json['full'] as bool? ?? false,
+    );
+  }
+
+  int get totalNeeded => baseMembersCount + neededMembers;
+  int get currentCount => baseMembersCount + acceptedCount;
+  double get progressRatio =>
+      neededMembers > 0 ? (acceptedCount / neededMembers).clamp(0.0, 1.0) : 0.0;
+
+  String get gameFormatDisplay {
+    switch (gameFormat) {
+      case 'THREE_VS_THREE':
+        return '3:3';
+      case 'FOUR_VS_FOUR':
+        return '4:4';
+      case 'FIVE_VS_FIVE':
+        return '5:5';
+      case 'FLEXIBLE':
+        return '자유';
+      default:
+        return gameFormat;
+    }
+  }
+
+  String get statusDisplay {
+    switch (status) {
+      case 'OPEN':
+        return '모집중';
+      case 'CONFIRMED':
+        return '확정';
+      case 'CLOSED':
+        return '마감';
+      case 'CANCELLED':
+        return '취소';
+      default:
+        return status;
+    }
+  }
+
+  bool get isOpen => status == 'OPEN';
+}
+
+class RecruitmentDetailModel {
+  final String id;
+  final int authorId;
+  final String authorNickname;
+  final DateTime startAt;
+  final DateTime endAt;
+  final String locationId;
+  final String locationName;
+  final int baseMembersCount;
+  final int neededMembers;
+  final int acceptedCount;
+  final String gameFormat;
+  final String status;
+  final DateTime? deadlineAt;
+  final DateTime createdAt;
+  final bool isFull;
+  final List<ApplicationModel> applications;
+
+  RecruitmentDetailModel({
+    required this.id,
+    required this.authorId,
+    required this.authorNickname,
+    required this.startAt,
+    required this.endAt,
+    required this.locationId,
+    required this.locationName,
+    required this.baseMembersCount,
+    required this.neededMembers,
+    required this.acceptedCount,
+    required this.gameFormat,
+    required this.status,
+    this.deadlineAt,
+    required this.createdAt,
+    required this.isFull,
+    required this.applications,
+  });
+
+  factory RecruitmentDetailModel.fromJson(Map<String, dynamic> json) {
+    final appsList = json['applications'] as List<dynamic>? ?? [];
+    return RecruitmentDetailModel(
+      id: json['id']?.toString() ?? '',
+      authorId: (json['authorId'] as num?)?.toInt() ?? 0,
+      authorNickname: json['authorNickname'] as String? ?? '',
+      startAt: DateTime.parse(json['startAt'] as String),
+      endAt: DateTime.parse(json['endAt'] as String),
+      locationId: json['locationId']?.toString() ?? '',
+      locationName: json['locationName'] as String? ?? '',
+      baseMembersCount: (json['baseMembersCount'] as num?)?.toInt() ?? 0,
+      neededMembers: (json['neededMembers'] as num?)?.toInt() ?? 0,
+      acceptedCount: (json['acceptedCount'] as num?)?.toInt() ?? 0,
+      gameFormat: json['gameFormat'] as String? ?? 'FLEXIBLE',
+      status: json['status'] as String? ?? 'OPEN',
+      deadlineAt: json['deadlineAt'] != null
+          ? DateTime.parse(json['deadlineAt'] as String)
+          : null,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      isFull: json['isFull'] as bool? ?? json['full'] as bool? ?? false,
+      applications: appsList
+          .map((e) => ApplicationModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  int get currentCount => baseMembersCount + acceptedCount;
+  int get totalNeeded => baseMembersCount + neededMembers;
+  double get progressRatio =>
+      neededMembers > 0 ? (acceptedCount / neededMembers).clamp(0.0, 1.0) : 0.0;
+
+  String get gameFormatDisplay {
+    switch (gameFormat) {
+      case 'THREE_VS_THREE':
+        return '3:3';
+      case 'FOUR_VS_FOUR':
+        return '4:4';
+      case 'FIVE_VS_FIVE':
+        return '5:5';
+      case 'FLEXIBLE':
+        return '자유';
+      default:
+        return gameFormat;
+    }
+  }
+
+  String get statusDisplay {
+    switch (status) {
+      case 'OPEN':
+        return '모집중';
+      case 'CONFIRMED':
+        return '확정';
+      case 'CLOSED':
+        return '마감';
+      case 'CANCELLED':
+        return '취소';
+      default:
+        return status;
+    }
+  }
+
+  bool get isOpen => status == 'OPEN';
+}
+
+class ApplicationModel {
+  final String applicationId;
+  final int applicantId;
+  final String applicantNickname;
+  final String? applicantPosition;
+  final int applicantExp;
+  final int applicantNoShowCount;
+  final int applicantParticipationCount;
+  final String status;
+  final String? message;
+  final DateTime createdAt;
+
+  ApplicationModel({
+    required this.applicationId,
+    required this.applicantId,
+    required this.applicantNickname,
+    this.applicantPosition,
+    required this.applicantExp,
+    required this.applicantNoShowCount,
+    required this.applicantParticipationCount,
+    required this.status,
+    this.message,
+    required this.createdAt,
+  });
+
+  factory ApplicationModel.fromJson(Map<String, dynamic> json) {
+    return ApplicationModel(
+      applicationId: json['applicationId']?.toString() ?? '',
+      applicantId: (json['applicantId'] as num?)?.toInt() ?? 0,
+      applicantNickname: json['applicantNickname'] as String? ?? '',
+      applicantPosition: json['applicantPosition'] as String?,
+      applicantExp: (json['applicantExp'] as num?)?.toInt() ?? 0,
+      applicantNoShowCount: (json['applicantNoShowCount'] as num?)?.toInt() ?? 0,
+      applicantParticipationCount:
+          (json['applicantParticipationCount'] as num?)?.toInt() ?? 0,
+      status: json['status'] as String? ?? 'PENDING',
+      message: json['message'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  bool get isPending => status == 'PENDING';
+  bool get isAccepted => status == 'ACCEPTED';
+  bool get isRejected => status == 'REJECTED';
+
+  String get positionDisplay {
+    switch (applicantPosition) {
+      case 'GUARD':
+        return '가드';
+      case 'FORWARD':
+        return '포워드';
+      case 'CENTER':
+        return '센터';
+      default:
+        return applicantPosition ?? '미설정';
+    }
+  }
+}

--- a/frontend/lib/data/models/recruitment_model.dart
+++ b/frontend/lib/data/models/recruitment_model.dart
@@ -29,23 +29,26 @@ class RecruitmentListModel {
     required this.isFull,
   });
 
+  static DateTime _parseDateTime(dynamic v) =>
+      DateTime.parse((v as String?)?.toString() ?? '');
+
   factory RecruitmentListModel.fromJson(Map<String, dynamic> json) {
     return RecruitmentListModel(
       id: json['id']?.toString() ?? '',
-      authorNickname: json['authorNickname'] as String? ?? '',
-      startAt: DateTime.parse(json['startAt'] as String),
-      endAt: DateTime.parse(json['endAt'] as String),
-      locationName: json['locationName'] as String? ?? '',
+      authorNickname: (json['authorNickname'] as String?) ?? '',
+      startAt: _parseDateTime(json['startAt']),
+      endAt: _parseDateTime(json['endAt']),
+      locationName: (json['locationName'] as String?) ?? '',
       baseMembersCount: (json['baseMembersCount'] as num?)?.toInt() ?? 0,
       neededMembers: (json['neededMembers'] as num?)?.toInt() ?? 0,
       acceptedCount: (json['acceptedCount'] as num?)?.toInt() ?? 0,
-      gameFormat: json['gameFormat'] as String? ?? 'FLEXIBLE',
-      status: json['status'] as String? ?? 'OPEN',
+      gameFormat: (json['gameFormat'] as String?) ?? 'FLEXIBLE',
+      status: (json['status'] as String?) ?? 'OPEN',
       deadlineAt: json['deadlineAt'] != null
-          ? DateTime.parse(json['deadlineAt'] as String)
+          ? _parseDateTime(json['deadlineAt'])
           : null,
-      createdAt: DateTime.parse(json['createdAt'] as String),
-      isFull: json['isFull'] as bool? ?? json['full'] as bool? ?? false,
+      createdAt: _parseDateTime(json['createdAt']),
+      isFull: (json['isFull'] as bool?) ?? (json['full'] as bool?) ?? false,
     );
   }
 
@@ -129,21 +132,21 @@ class RecruitmentDetailModel {
     return RecruitmentDetailModel(
       id: json['id']?.toString() ?? '',
       authorId: (json['authorId'] as num?)?.toInt() ?? 0,
-      authorNickname: json['authorNickname'] as String? ?? '',
-      startAt: DateTime.parse(json['startAt'] as String),
-      endAt: DateTime.parse(json['endAt'] as String),
+      authorNickname: (json['authorNickname'] as String?) ?? '',
+      startAt: RecruitmentListModel._parseDateTime(json['startAt']),
+      endAt: RecruitmentListModel._parseDateTime(json['endAt']),
       locationId: json['locationId']?.toString() ?? '',
-      locationName: json['locationName'] as String? ?? '',
+      locationName: (json['locationName'] as String?) ?? '',
       baseMembersCount: (json['baseMembersCount'] as num?)?.toInt() ?? 0,
       neededMembers: (json['neededMembers'] as num?)?.toInt() ?? 0,
       acceptedCount: (json['acceptedCount'] as num?)?.toInt() ?? 0,
-      gameFormat: json['gameFormat'] as String? ?? 'FLEXIBLE',
-      status: json['status'] as String? ?? 'OPEN',
+      gameFormat: (json['gameFormat'] as String?) ?? 'FLEXIBLE',
+      status: (json['status'] as String?) ?? 'OPEN',
       deadlineAt: json['deadlineAt'] != null
-          ? DateTime.parse(json['deadlineAt'] as String)
+          ? RecruitmentListModel._parseDateTime(json['deadlineAt'])
           : null,
-      createdAt: DateTime.parse(json['createdAt'] as String),
-      isFull: json['isFull'] as bool? ?? json['full'] as bool? ?? false,
+      createdAt: RecruitmentListModel._parseDateTime(json['createdAt']),
+      isFull: (json['isFull'] as bool?) ?? (json['full'] as bool?) ?? false,
       applications: appsList
           .map((e) => ApplicationModel.fromJson(e as Map<String, dynamic>))
           .toList(),
@@ -217,15 +220,15 @@ class ApplicationModel {
     return ApplicationModel(
       applicationId: json['applicationId']?.toString() ?? '',
       applicantId: (json['applicantId'] as num?)?.toInt() ?? 0,
-      applicantNickname: json['applicantNickname'] as String? ?? '',
+      applicantNickname: (json['applicantNickname'] as String?) ?? '',
       applicantPosition: json['applicantPosition'] as String?,
       applicantExp: (json['applicantExp'] as num?)?.toInt() ?? 0,
       applicantNoShowCount: (json['applicantNoShowCount'] as num?)?.toInt() ?? 0,
       applicantParticipationCount:
           (json['applicantParticipationCount'] as num?)?.toInt() ?? 0,
-      status: json['status'] as String? ?? 'PENDING',
+      status: (json['status'] as String?) ?? 'PENDING',
       message: json['message'] as String?,
-      createdAt: DateTime.parse(json['createdAt'] as String),
+      createdAt: RecruitmentListModel._parseDateTime(json['createdAt']),
     );
   }
 

--- a/frontend/lib/data/models/recruitment_model.dart
+++ b/frontend/lib/data/models/recruitment_model.dart
@@ -29,8 +29,17 @@ class RecruitmentListModel {
     required this.isFull,
   });
 
-  static DateTime _parseDateTime(dynamic v) =>
-      DateTime.parse((v as String?)?.toString() ?? '');
+  /// ISO-8601 문자열 또는 epoch ms 지원. null/빈값/실패 시 DateTime.now() 반환 (크래시 방지)
+  static DateTime _parseDateTime(dynamic v) {
+    if (v == null) return DateTime.now();
+    if (v is num) {
+      final ms = v.toInt();
+      return DateTime.fromMillisecondsSinceEpoch(ms > 9999999999 ? ms : ms * 1000);
+    }
+    final s = (v as String?)?.toString().trim();
+    if (s == null || s.isEmpty) return DateTime.now();
+    return DateTime.tryParse(s) ?? DateTime.now();
+  }
 
   factory RecruitmentListModel.fromJson(Map<String, dynamic> json) {
     return RecruitmentListModel(

--- a/frontend/lib/data/models/user_model.dart
+++ b/frontend/lib/data/models/user_model.dart
@@ -1,8 +1,3 @@
-import 'package:json_annotation/json_annotation.dart';
-
-part 'user_model.g.dart';
-
-@JsonSerializable()
 class UserModel {
   final int userId;
   final String email;
@@ -15,6 +10,11 @@ class UserModel {
   final String? department;
   final String? studentId;
   final DateTime createdAt;
+  final String? nickname;
+  final String? position;
+  final int exp;
+  final int noShowCount;
+  final int participationCount;
 
   UserModel({
     required this.userId,
@@ -28,11 +28,71 @@ class UserModel {
     this.department,
     this.studentId,
     required this.createdAt,
+    this.nickname,
+    this.position,
+    this.exp = 0,
+    this.noShowCount = 0,
+    this.participationCount = 0,
   });
 
-  factory UserModel.fromJson(Map<String, dynamic> json) =>
-      _$UserModelFromJson(json);
+  factory UserModel.fromJson(Map<String, dynamic> json) {
+    return UserModel(
+      userId: json['userId'] as int,
+      email: json['email'] as String? ?? '',
+      realName: json['realName'] as String? ?? '',
+      phoneNumber: json['phoneNumber'] as String?,
+      profileImageUrl: json['profileImageUrl'] as String?,
+      loginType: json['loginType'] as String? ?? 'EMAIL',
+      dateOfBirth: json['dateOfBirth'] as String?,
+      isPnuStudent: json['isPnuStudent'] as bool?,
+      department: json['department'] as String?,
+      studentId: json['studentId'] as String?,
+      createdAt: json['createdAt'] != null
+          ? DateTime.parse(json['createdAt'] as String)
+          : DateTime.now(),
+      nickname: json['nickname'] as String?,
+      position: json['position'] as String?,
+      exp: (json['exp'] as num?)?.toInt() ?? 0,
+      noShowCount: (json['noShowCount'] as num?)?.toInt() ?? 0,
+      participationCount: (json['participationCount'] as num?)?.toInt() ?? 0,
+    );
+  }
 
-  Map<String, dynamic> toJson() => _$UserModelToJson(this);
+  Map<String, dynamic> toJson() => {
+        'userId': userId,
+        'email': email,
+        'realName': realName,
+        'phoneNumber': phoneNumber,
+        'profileImageUrl': profileImageUrl,
+        'loginType': loginType,
+        'dateOfBirth': dateOfBirth,
+        'isPnuStudent': isPnuStudent,
+        'department': department,
+        'studentId': studentId,
+        'createdAt': createdAt.toIso8601String(),
+        'nickname': nickname,
+        'position': position,
+        'exp': exp,
+        'noShowCount': noShowCount,
+        'participationCount': participationCount,
+      };
+
+  String get positionDisplayName {
+    switch (position) {
+      case 'GUARD':
+        return '가드';
+      case 'FORWARD':
+        return '포워드';
+      case 'CENTER':
+        return '센터';
+      default:
+        return position ?? '미설정';
+    }
+  }
+
+  String get expLevelName {
+    if (exp >= 300) return '올스타';
+    if (exp >= 100) return '슈터';
+    return '루키';
+  }
 }
-

--- a/frontend/lib/data/repositories/auth_repository.dart
+++ b/frontend/lib/data/repositories/auth_repository.dart
@@ -326,6 +326,8 @@ class AuthRepository {
 
   // 추가 정보 입력 (구글 신규 사용자)
   Future<UserModel> completeProfile({
+    required String nickname,
+    required String position,
     required String? realName,
     required String dateOfBirth,
     required bool isPnuStudent,
@@ -337,6 +339,8 @@ class AuthRepository {
 
     final response = await authService.completeProfile(
       accessToken: accessToken,
+      nickname: nickname,
+      position: position,
       realName: realName,
       dateOfBirth: dateOfBirth,
       isPnuStudent: isPnuStudent,

--- a/frontend/lib/data/repositories/club_match_repository.dart
+++ b/frontend/lib/data/repositories/club_match_repository.dart
@@ -1,0 +1,97 @@
+import '../models/club_match_model.dart';
+import '../services/club_match_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class ClubMatchRepository {
+  final ClubMatchService service;
+  final FlutterSecureStorage secureStorage;
+
+  ClubMatchRepository({
+    ClubMatchService? service,
+    FlutterSecureStorage? secureStorage,
+  })  : service = service ?? ClubMatchService(),
+        secureStorage = secureStorage ?? const FlutterSecureStorage();
+
+  Future<String> _getToken() async {
+    final token = await secureStorage.read(key: 'access_token');
+    if (token == null) throw Exception('로그인이 필요합니다.');
+    return token;
+  }
+
+  Future<List<ClubMatchRequestModel>> getRequests() async {
+    final token = await _getToken();
+    final response = await service.getRequests(accessToken: token);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '친선전 목록 조회 실패');
+  }
+
+  Future<ClubMatchRequestModel> getRequest(String id) async {
+    final token = await _getToken();
+    final response = await service.getRequest(accessToken: token, id: id);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '친선전 상세 조회 실패');
+  }
+
+  Future<ClubMatchRequestModel> create({
+    required String startAt,
+    required String endAt,
+    required String locationId,
+    String? awayClubId,
+  }) async {
+    final token = await _getToken();
+    final response = await service.create(
+      accessToken: token,
+      body: {
+        'startAt': startAt,
+        'endAt': endAt,
+        'locationId': locationId,
+        if (awayClubId != null) 'awayClubId': awayClubId,
+      },
+    );
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '친선전 신청 실패');
+  }
+
+  Future<void> attend(String id) async {
+    final token = await _getToken();
+    final response = await service.attend(accessToken: token, id: id);
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '참가 의사 등록 실패');
+    }
+  }
+
+  Future<ClubMatchRequestModel> matchOpponent(String id, String awayClubId) async {
+    final token = await _getToken();
+    final response = await service.matchOpponent(
+      accessToken: token,
+      id: id,
+      awayClubId: awayClubId,
+    );
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '상대 지정 실패');
+  }
+
+  Future<ClubMatchResultModel> submitResult(
+    String id, {
+    required int homeScore,
+    required int awayScore,
+  }) async {
+    final token = await _getToken();
+    final response = await service.submitResult(
+      accessToken: token,
+      id: id,
+      homeScore: homeScore,
+      awayScore: awayScore,
+    );
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '결과 입력 실패');
+  }
+
+  Future<void> approveResult(String id) async {
+    final token = await _getToken();
+    final response = await service.approveResult(accessToken: token, id: id);
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '결과 승인 실패');
+    }
+  }
+}

--- a/frontend/lib/data/repositories/match_repository.dart
+++ b/frontend/lib/data/repositories/match_repository.dart
@@ -1,0 +1,66 @@
+import '../models/match_model.dart';
+import '../services/match_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class MatchRepository {
+  final MatchService service;
+  final FlutterSecureStorage secureStorage;
+
+  MatchRepository({
+    MatchService? service,
+    FlutterSecureStorage? secureStorage,
+  })  : service = service ?? MatchService(),
+        secureStorage = secureStorage ?? const FlutterSecureStorage();
+
+  Future<String> _getToken() async {
+    final token = await secureStorage.read(key: 'access_token');
+    if (token == null) throw Exception('로그인이 필요합니다.');
+    return token;
+  }
+
+  Future<List<MatchModel>> getMyMatches() async {
+    final token = await _getToken();
+    final response = await service.getMyMatches(accessToken: token);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '경기 목록 조회 실패');
+  }
+
+  Future<MatchModel> getMatch(String id) async {
+    final token = await _getToken();
+    final response = await service.getMatch(accessToken: token, id: id);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '경기 조회 실패');
+  }
+
+  Future<void> complete(String id) async {
+    final token = await _getToken();
+    final response = await service.complete(accessToken: token, id: id);
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '경기 완료 처리 실패');
+    }
+  }
+
+  Future<ReviewFormModel> getReviewForm(String id) async {
+    final token = await _getToken();
+    final response = await service.getReviewForm(accessToken: token, id: id);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '리뷰 폼 조회 실패');
+  }
+
+  Future<void> submitReview(
+    String id, {
+    required List<int> thumbsUpUserIds,
+    required List<int> noShowUserIds,
+  }) async {
+    final token = await _getToken();
+    final response = await service.submitReview(
+      accessToken: token,
+      id: id,
+      thumbsUpUserIds: thumbsUpUserIds,
+      noShowUserIds: noShowUserIds,
+    );
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '리뷰 제출 실패');
+    }
+  }
+}

--- a/frontend/lib/data/repositories/recruitment_repository.dart
+++ b/frontend/lib/data/repositories/recruitment_repository.dart
@@ -1,0 +1,130 @@
+import '../models/recruitment_model.dart';
+import '../services/recruitment_service.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+
+class RecruitmentRepository {
+  final RecruitmentService service;
+  final FlutterSecureStorage secureStorage;
+
+  RecruitmentRepository({
+    RecruitmentService? service,
+    FlutterSecureStorage? secureStorage,
+  })  : service = service ?? RecruitmentService(),
+        secureStorage = secureStorage ?? const FlutterSecureStorage();
+
+  Future<String> _getToken() async {
+    final token = await secureStorage.read(key: 'access_token');
+    if (token == null) throw Exception('로그인이 필요합니다.');
+    return token;
+  }
+
+  Future<List<RecruitmentListModel>> getList({
+    String? status,
+    String? locationId,
+    String? gameFormat,
+    int page = 0,
+    int size = 20,
+  }) async {
+    final token = await _getToken();
+    final response = await service.getList(
+      accessToken: token,
+      status: status,
+      locationId: locationId,
+      gameFormat: gameFormat,
+      page: page,
+      size: size,
+    );
+
+    if (response.success && response.data != null) {
+      final content = response.data!['content'] as List<dynamic>? ?? [];
+      return content
+          .map((e) => RecruitmentListModel.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+    throw Exception(response.error?['message'] ?? '모집글 목록 조회 실패');
+  }
+
+  Future<RecruitmentDetailModel> getDetail(String id) async {
+    final token = await _getToken();
+    final response = await service.getDetail(accessToken: token, id: id);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '모집글 상세 조회 실패');
+  }
+
+  Future<RecruitmentDetailModel> create({
+    required String startAt,
+    required String endAt,
+    required String locationId,
+    required int baseMembersCount,
+    required int neededMembers,
+    required String gameFormat,
+    String? deadlineAt,
+  }) async {
+    final token = await _getToken();
+    final response = await service.create(
+      accessToken: token,
+      body: {
+        'startAt': startAt,
+        'endAt': endAt,
+        'locationId': locationId,
+        'baseMembersCount': baseMembersCount,
+        'neededMembers': neededMembers,
+        'gameFormat': gameFormat,
+        if (deadlineAt != null) 'deadlineAt': deadlineAt,
+      },
+    );
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '모집글 생성 실패');
+  }
+
+  Future<void> apply(String id, {String? message}) async {
+    final token = await _getToken();
+    final response = await service.apply(
+      accessToken: token,
+      id: id,
+      message: message,
+    );
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '신청 실패');
+    }
+  }
+
+  Future<void> acceptApplication(String recruitmentId, String applicationId) async {
+    final token = await _getToken();
+    final response = await service.acceptApplication(
+      accessToken: token,
+      recruitmentId: recruitmentId,
+      applicationId: applicationId,
+    );
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '수락 실패');
+    }
+  }
+
+  Future<void> rejectApplication(String recruitmentId, String applicationId) async {
+    final token = await _getToken();
+    final response = await service.rejectApplication(
+      accessToken: token,
+      recruitmentId: recruitmentId,
+      applicationId: applicationId,
+    );
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '거절 실패');
+    }
+  }
+
+  Future<RecruitmentDetailModel> confirm(String id) async {
+    final token = await _getToken();
+    final response = await service.confirm(accessToken: token, id: id);
+    if (response.success && response.data != null) return response.data!;
+    throw Exception(response.error?['message'] ?? '확정 실패');
+  }
+
+  Future<void> cancel(String id) async {
+    final token = await _getToken();
+    final response = await service.cancel(accessToken: token, id: id);
+    if (!response.success) {
+      throw Exception(response.error?['message'] ?? '취소 실패');
+    }
+  }
+}

--- a/frontend/lib/data/services/api_service.dart
+++ b/frontend/lib/data/services/api_service.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import '../models/api_response_model.dart';
 import '../../core/constants/api_endpoints.dart';
+import '../../core/auth/session_expired_handler.dart';
 
 class ApiService {
   final String baseUrl;
@@ -94,6 +95,12 @@ class ApiService {
     http.Response response,
     T Function(Object?)? fromJson,
   ) {
+    // 401: 토큰 없음/만료 → 로그인 화면으로
+    if (response.statusCode == 401) {
+      SessionExpiredHandler.trigger();
+      throw Exception('로그인이 만료되었습니다.');
+    }
+
     final responseBody = utf8.decode(response.bodyBytes);
     final contentType = response.headers['content-type'] ?? '';
 

--- a/frontend/lib/data/services/auth_service.dart
+++ b/frontend/lib/data/services/auth_service.dart
@@ -126,6 +126,8 @@ class AuthService {
 
   Future<ApiResponseModel<UserModel>> completeProfile({
     required String accessToken,
+    required String nickname,
+    required String position,
     required String? realName,
     required String dateOfBirth,
     required bool isPnuStudent,
@@ -136,6 +138,8 @@ class AuthService {
       ApiEndpoints.completeProfile,
       headers: {'Authorization': 'Bearer $accessToken'},
       body: {
+        'nickname': nickname,
+        'position': position,
         if (realName != null) 'realName': realName,
         'dateOfBirth': dateOfBirth,
         'isPnuStudent': isPnuStudent,

--- a/frontend/lib/data/services/club_match_service.dart
+++ b/frontend/lib/data/services/club_match_service.dart
@@ -1,0 +1,98 @@
+import '../models/api_response_model.dart';
+import '../models/club_match_model.dart';
+import 'api_service.dart';
+import '../../core/constants/api_endpoints.dart';
+
+class ClubMatchService {
+  final ApiService apiService;
+
+  ClubMatchService({ApiService? apiService})
+      : apiService = apiService ?? ApiService();
+
+  Future<ApiResponseModel<List<ClubMatchRequestModel>>> getRequests({
+    required String accessToken,
+  }) async {
+    return await apiService.get<List<ClubMatchRequestModel>>(
+      ApiEndpoints.clubMatchRequests,
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) => (json as List)
+          .map((e) =>
+              ClubMatchRequestModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Future<ApiResponseModel<ClubMatchRequestModel>> getRequest({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.get<ClubMatchRequestModel>(
+      ApiEndpoints.clubMatchRequest(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) =>
+          ClubMatchRequestModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<ClubMatchRequestModel>> create({
+    required String accessToken,
+    required Map<String, dynamic> body,
+  }) async {
+    return await apiService.post<ClubMatchRequestModel>(
+      ApiEndpoints.clubMatchRequests,
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: body,
+      fromJson: (json) =>
+          ClubMatchRequestModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> attend({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.clubMatchAttend(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+
+  Future<ApiResponseModel<ClubMatchRequestModel>> matchOpponent({
+    required String accessToken,
+    required String id,
+    required String awayClubId,
+  }) async {
+    return await apiService.post<ClubMatchRequestModel>(
+      ApiEndpoints.clubMatchMatch(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: {'awayClubId': awayClubId},
+      fromJson: (json) =>
+          ClubMatchRequestModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<ClubMatchResultModel>> submitResult({
+    required String accessToken,
+    required String id,
+    required int homeScore,
+    required int awayScore,
+  }) async {
+    return await apiService.post<ClubMatchResultModel>(
+      ApiEndpoints.clubMatchResult(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: {'homeScore': homeScore, 'awayScore': awayScore},
+      fromJson: (json) =>
+          ClubMatchResultModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> approveResult({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.clubMatchApproveResult(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+}

--- a/frontend/lib/data/services/match_service.dart
+++ b/frontend/lib/data/services/match_service.dart
@@ -1,0 +1,72 @@
+import '../models/api_response_model.dart';
+import '../models/match_model.dart';
+import 'api_service.dart';
+import '../../core/constants/api_endpoints.dart';
+
+class MatchService {
+  final ApiService apiService;
+
+  MatchService({ApiService? apiService})
+      : apiService = apiService ?? ApiService();
+
+  Future<ApiResponseModel<List<MatchModel>>> getMyMatches({
+    required String accessToken,
+  }) async {
+    return await apiService.get<List<MatchModel>>(
+      ApiEndpoints.matches,
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) => (json as List)
+          .map((e) => MatchModel.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+  }
+
+  Future<ApiResponseModel<MatchModel>> getMatch({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.get<MatchModel>(
+      ApiEndpoints.match(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) => MatchModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> complete({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.matchComplete(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+
+  Future<ApiResponseModel<ReviewFormModel>> getReviewForm({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.get<ReviewFormModel>(
+      ApiEndpoints.matchReviewForm(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) =>
+          ReviewFormModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> submitReview({
+    required String accessToken,
+    required String id,
+    required List<int> thumbsUpUserIds,
+    required List<int> noShowUserIds,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.matchReview(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: {
+        'thumbsUpUserIds': thumbsUpUserIds,
+        'noShowUserIds': noShowUserIds,
+      },
+    );
+  }
+}

--- a/frontend/lib/data/services/recruitment_service.dart
+++ b/frontend/lib/data/services/recruitment_service.dart
@@ -1,0 +1,121 @@
+import '../models/api_response_model.dart';
+import '../models/recruitment_model.dart';
+import 'api_service.dart';
+import '../../core/constants/api_endpoints.dart';
+
+class RecruitmentService {
+  final ApiService apiService;
+
+  RecruitmentService({ApiService? apiService})
+      : apiService = apiService ?? ApiService();
+
+  Future<ApiResponseModel<Map<String, dynamic>>> getList({
+    required String accessToken,
+    String? status,
+    String? locationId,
+    String? gameFormat,
+    String? startFrom,
+    String? startTo,
+    int page = 0,
+    int size = 20,
+  }) async {
+    final params = <String, String>{
+      'page': page.toString(),
+      'size': size.toString(),
+    };
+    if (status != null) params['status'] = status;
+    if (locationId != null) params['locationId'] = locationId;
+    if (gameFormat != null) params['gameFormat'] = gameFormat;
+    if (startFrom != null) params['startFrom'] = startFrom;
+    if (startTo != null) params['startTo'] = startTo;
+
+    final query = params.entries.map((e) => '${e.key}=${e.value}').join('&');
+
+    return await apiService.get<Map<String, dynamic>>(
+      '${ApiEndpoints.recruitments}?$query',
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) => json as Map<String, dynamic>,
+    );
+  }
+
+  Future<ApiResponseModel<RecruitmentDetailModel>> getDetail({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.get<RecruitmentDetailModel>(
+      ApiEndpoints.recruitment(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) =>
+          RecruitmentDetailModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<RecruitmentDetailModel>> create({
+    required String accessToken,
+    required Map<String, dynamic> body,
+  }) async {
+    return await apiService.post<RecruitmentDetailModel>(
+      ApiEndpoints.recruitments,
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: body,
+      fromJson: (json) =>
+          RecruitmentDetailModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> apply({
+    required String accessToken,
+    required String id,
+    String? message,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.recruitmentApply(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      body: {if (message != null) 'message': message},
+    );
+  }
+
+  Future<ApiResponseModel<void>> acceptApplication({
+    required String accessToken,
+    required String recruitmentId,
+    required String applicationId,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.recruitmentApplicationAccept(recruitmentId, applicationId),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+
+  Future<ApiResponseModel<void>> rejectApplication({
+    required String accessToken,
+    required String recruitmentId,
+    required String applicationId,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.recruitmentApplicationReject(recruitmentId, applicationId),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+
+  Future<ApiResponseModel<RecruitmentDetailModel>> confirm({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.post<RecruitmentDetailModel>(
+      ApiEndpoints.recruitmentConfirm(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+      fromJson: (json) =>
+          RecruitmentDetailModel.fromJson(json as Map<String, dynamic>),
+    );
+  }
+
+  Future<ApiResponseModel<void>> cancel({
+    required String accessToken,
+    required String id,
+  }) async {
+    return await apiService.post<void>(
+      ApiEndpoints.recruitmentCancel(id),
+      headers: {'Authorization': 'Bearer $accessToken'},
+    );
+  }
+}

--- a/frontend/lib/presentation/providers/auth_provider.dart
+++ b/frontend/lib/presentation/providers/auth_provider.dart
@@ -225,6 +225,8 @@ class AuthProvider with ChangeNotifier {
   }
 
   Future<UserModel?> completeProfile({
+    required String nickname,
+    required String position,
     required String? realName,
     required String dateOfBirth,
     required bool isPnuStudent,
@@ -237,6 +239,8 @@ class AuthProvider with ChangeNotifier {
       notifyListeners();
 
       final user = await authRepository.completeProfile(
+        nickname: nickname,
+        position: position,
         realName: realName,
         dateOfBirth: dateOfBirth,
         isPnuStudent: isPnuStudent,

--- a/frontend/lib/presentation/providers/club_match_provider.dart
+++ b/frontend/lib/presentation/providers/club_match_provider.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/foundation.dart';
+import '../../core/utils/error_message_util.dart';
+import '../../data/models/club_match_model.dart';
+import '../../data/repositories/club_match_repository.dart';
+
+class ClubMatchProvider with ChangeNotifier {
+  final ClubMatchRepository repository;
+
+  List<ClubMatchRequestModel> _requests = [];
+  ClubMatchRequestModel? _selectedRequest;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  ClubMatchProvider({ClubMatchRepository? repository})
+      : repository = repository ?? ClubMatchRepository();
+
+  List<ClubMatchRequestModel> get requests => _requests;
+  ClubMatchRequestModel? get selectedRequest => _selectedRequest;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+
+  Future<void> loadRequests() async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _requests = await repository.getRequests();
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadDetail(String id) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _selectedRequest = await repository.getRequest(id);
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<ClubMatchRequestModel?> create({
+    required String startAt,
+    required String endAt,
+    required String locationId,
+    String? awayClubId,
+  }) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      final result = await repository.create(
+        startAt: startAt,
+        endAt: endAt,
+        locationId: locationId,
+        awayClubId: awayClubId,
+      );
+      await loadRequests();
+      return result;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      _isLoading = false;
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<bool> attend(String id) async {
+    try {
+      _errorMessage = null;
+      await repository.attend(id);
+      await loadDetail(id);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> matchOpponent(String id, String awayClubId) async {
+    try {
+      _errorMessage = null;
+      await repository.matchOpponent(id, awayClubId);
+      await loadDetail(id);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<ClubMatchResultModel?> submitResult(
+    String id, {
+    required int homeScore,
+    required int awayScore,
+  }) async {
+    try {
+      _errorMessage = null;
+      final result = await repository.submitResult(
+        id,
+        homeScore: homeScore,
+        awayScore: awayScore,
+      );
+      await loadDetail(id);
+      return result;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<bool> approveResult(String id) async {
+    try {
+      _errorMessage = null;
+      await repository.approveResult(id);
+      await loadDetail(id);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  void clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+}

--- a/frontend/lib/presentation/providers/match_provider.dart
+++ b/frontend/lib/presentation/providers/match_provider.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/foundation.dart';
+import '../../core/utils/error_message_util.dart';
+import '../../data/models/match_model.dart';
+import '../../data/repositories/match_repository.dart';
+
+class MatchProvider with ChangeNotifier {
+  final MatchRepository repository;
+
+  List<MatchModel> _matches = [];
+  MatchModel? _selectedMatch;
+  ReviewFormModel? _reviewForm;
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  MatchProvider({MatchRepository? repository})
+      : repository = repository ?? MatchRepository();
+
+  List<MatchModel> get matches => _matches;
+  MatchModel? get selectedMatch => _selectedMatch;
+  ReviewFormModel? get reviewForm => _reviewForm;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+
+  List<MatchModel> get pendingReviewMatches =>
+      _matches.where((m) => m.isEnded).toList();
+
+  Future<void> loadMyMatches() async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _matches = await repository.getMyMatches();
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadMatch(String id) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _selectedMatch = await repository.getMatch(id);
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> completeMatch(String id) async {
+    try {
+      _errorMessage = null;
+      await repository.complete(id);
+      await loadMyMatches();
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<ReviewFormModel?> loadReviewForm(String id) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _reviewForm = await repository.getReviewForm(id);
+      return _reviewForm;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      return null;
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<bool> submitReview(
+    String matchId, {
+    required List<int> thumbsUpUserIds,
+    required List<int> noShowUserIds,
+  }) async {
+    try {
+      _errorMessage = null;
+      await repository.submitReview(
+        matchId,
+        thumbsUpUserIds: thumbsUpUserIds,
+        noShowUserIds: noShowUserIds,
+      );
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  void clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+}

--- a/frontend/lib/presentation/providers/recruitment_provider.dart
+++ b/frontend/lib/presentation/providers/recruitment_provider.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/foundation.dart';
+import '../../core/utils/error_message_util.dart';
+import '../../data/models/recruitment_model.dart';
+
+import '../../data/repositories/recruitment_repository.dart';
+
+class RecruitmentProvider with ChangeNotifier {
+  final RecruitmentRepository repository;
+
+  List<RecruitmentListModel> _recruitments = [];
+  RecruitmentDetailModel? _selectedRecruitment;
+  bool _isLoading = false;
+  String? _errorMessage;
+  String? _filterStatus;
+  String? _filterLocationId;
+  String? _filterGameFormat;
+
+  RecruitmentProvider({RecruitmentRepository? repository})
+      : repository = repository ?? RecruitmentRepository();
+
+  List<RecruitmentListModel> get recruitments => _recruitments;
+  RecruitmentDetailModel? get selectedRecruitment => _selectedRecruitment;
+  bool get isLoading => _isLoading;
+  String? get errorMessage => _errorMessage;
+  String? get filterStatus => _filterStatus;
+  String? get filterLocationId => _filterLocationId;
+  String? get filterGameFormat => _filterGameFormat;
+
+  void setFilter({String? status, String? locationId, String? gameFormat}) {
+    _filterStatus = status;
+    _filterLocationId = locationId;
+    _filterGameFormat = gameFormat;
+    notifyListeners();
+    loadRecruitments();
+  }
+
+  void clearFilters() {
+    _filterStatus = null;
+    _filterLocationId = null;
+    _filterGameFormat = null;
+    notifyListeners();
+    loadRecruitments();
+  }
+
+  Future<void> loadRecruitments() async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _recruitments = await repository.getList(
+        status: _filterStatus,
+        locationId: _filterLocationId,
+        gameFormat: _filterGameFormat,
+      );
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<void> loadDetail(String id) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      _selectedRecruitment = await repository.getDetail(id);
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+    } finally {
+      _isLoading = false;
+      notifyListeners();
+    }
+  }
+
+  Future<RecruitmentDetailModel?> create({
+    required String startAt,
+    required String endAt,
+    required String locationId,
+    required int baseMembersCount,
+    required int neededMembers,
+    required String gameFormat,
+    String? deadlineAt,
+  }) async {
+    try {
+      _isLoading = true;
+      _errorMessage = null;
+      notifyListeners();
+
+      final result = await repository.create(
+        startAt: startAt,
+        endAt: endAt,
+        locationId: locationId,
+        baseMembersCount: baseMembersCount,
+        neededMembers: neededMembers,
+        gameFormat: gameFormat,
+        deadlineAt: deadlineAt,
+      );
+      await loadRecruitments();
+      return result;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      _isLoading = false;
+      notifyListeners();
+      return null;
+    }
+  }
+
+  Future<bool> apply(String id, {String? message}) async {
+    try {
+      _errorMessage = null;
+      await repository.apply(id, message: message);
+      await loadDetail(id);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> acceptApplication(String recruitmentId, String applicationId) async {
+    try {
+      _errorMessage = null;
+      await repository.acceptApplication(recruitmentId, applicationId);
+      await loadDetail(recruitmentId);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> rejectApplication(String recruitmentId, String applicationId) async {
+    try {
+      _errorMessage = null;
+      await repository.rejectApplication(recruitmentId, applicationId);
+      await loadDetail(recruitmentId);
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> confirm(String id) async {
+    try {
+      _errorMessage = null;
+      await repository.confirm(id);
+      await loadDetail(id);
+      await loadRecruitments();
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  Future<bool> cancel(String id) async {
+    try {
+      _errorMessage = null;
+      await repository.cancel(id);
+      await loadRecruitments();
+      return true;
+    } catch (e) {
+      _errorMessage = toUserFriendlyMessage(e);
+      notifyListeners();
+      return false;
+    }
+  }
+
+  void clearError() {
+    _errorMessage = null;
+    notifyListeners();
+  }
+}

--- a/frontend/lib/presentation/screens/auth/complete_profile_screen.dart
+++ b/frontend/lib/presentation/screens/auth/complete_profile_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
 import '../../providers/auth_provider.dart';
 
 class CompleteProfileScreen extends StatefulWidget {
@@ -12,14 +13,23 @@ class CompleteProfileScreen extends StatefulWidget {
 
 class _CompleteProfileScreenState extends State<CompleteProfileScreen> {
   final _formKey = GlobalKey<FormState>();
+  final _nicknameController = TextEditingController();
   final _realNameController = TextEditingController();
   final _dateOfBirthController = TextEditingController();
   final _departmentController = TextEditingController();
   final _studentIdController = TextEditingController();
   bool _isPnuStudent = true;
+  String? _selectedPosition;
+
+  static const _positions = [
+    {'value': 'GUARD', 'label': '가드'},
+    {'value': 'FORWARD', 'label': '포워드'},
+    {'value': 'CENTER', 'label': '센터'},
+  ];
 
   @override
   void dispose() {
+    _nicknameController.dispose();
     _realNameController.dispose();
     _dateOfBirthController.dispose();
     _departmentController.dispose();
@@ -37,6 +47,8 @@ class _CompleteProfileScreenState extends State<CompleteProfileScreen> {
         : _dateOfBirthController.text.trim();
 
     final user = await authProvider.completeProfile(
+      nickname: _nicknameController.text.trim(),
+      position: _selectedPosition!,
       realName: _realNameController.text.trim().isEmpty
           ? null
           : _realNameController.text.trim(),
@@ -83,6 +95,67 @@ class _CompleteProfileScreenState extends State<CompleteProfileScreen> {
                   style: TextStyle(fontSize: 16),
                 ),
                 const SizedBox(height: 24),
+                TextFormField(
+                  controller: _nicknameController,
+                  decoration: const InputDecoration(
+                    labelText: '닉네임 *',
+                    hintText: '2~30자, 앱 내 활동에 사용됩니다',
+                    border: OutlineInputBorder(),
+                    prefixIcon: Icon(Icons.badge_outlined),
+                  ),
+                  validator: (value) {
+                    if (value == null || value.trim().isEmpty) {
+                      return '닉네임을 입력해주세요';
+                    }
+                    if (value.trim().length < 2 || value.trim().length > 30) {
+                      return '닉네임은 2~30자 사이여야 합니다';
+                    }
+                    return null;
+                  },
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '주 포지션 *',
+                  style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: _positions.map((pos) {
+                    final isSelected = _selectedPosition == pos['value'];
+                    return Expanded(
+                      child: Padding(
+                        padding: EdgeInsets.only(
+                          right: pos != _positions.last ? 8.0 : 0,
+                        ),
+                        child: ChoiceChip(
+                          label: SizedBox(
+                            width: double.infinity,
+                            child: Text(
+                              pos['label']!,
+                              textAlign: TextAlign.center,
+                              style: TextStyle(
+                                color: isSelected ? Colors.white : AppColors.titleText,
+                                fontWeight: isSelected ? FontWeight.bold : FontWeight.normal,
+                              ),
+                            ),
+                          ),
+                          selected: isSelected,
+                          selectedColor: AppColors.activeBlue,
+                          onSelected: (_) {
+                            setState(() => _selectedPosition = pos['value']);
+                          },
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+                if (_selectedPosition == null) ...[
+                  const SizedBox(height: 4),
+                ],
+                Builder(builder: (context) {
+                  return const SizedBox.shrink();
+                }),
+                const SizedBox(height: 16),
                 TextFormField(
                   controller: _realNameController,
                   decoration: const InputDecoration(
@@ -174,7 +247,20 @@ class _CompleteProfileScreenState extends State<CompleteProfileScreen> {
                 Consumer<AuthProvider>(
                   builder: (context, authProvider, _) {
                     return ElevatedButton(
-                      onPressed: authProvider.isLoading ? null : _handleComplete,
+                      onPressed: authProvider.isLoading
+                          ? null
+                          : () {
+                              if (_selectedPosition == null) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('포지션을 선택해주세요'),
+                                    backgroundColor: Colors.red,
+                                  ),
+                                );
+                                return;
+                              }
+                              _handleComplete();
+                            },
                       style: ElevatedButton.styleFrom(
                         padding: const EdgeInsets.symmetric(vertical: 16),
                       ),

--- a/frontend/lib/presentation/screens/club/club_screen.dart
+++ b/frontend/lib/presentation/screens/club/club_screen.dart
@@ -74,16 +74,18 @@ class _ClubScreenState extends State<ClubScreen> {
   }
 
   // --- 1. 내 동아리 상세 뷰 (가입된 경우) ---
+  // 탭 순서: 순위(디폴트) → 내 동아리 → 멤버
   Widget _buildMyClubDetailView(ClubModel club) {
     return DefaultTabController(
       length: 3,
+      initialIndex: 0, // 순위 디폴트
       child: Scaffold(
         backgroundColor: AppColors.pageBg,
         appBar: AppBar(
           backgroundColor: AppColors.headerGrey,
           elevation: 0,
           title: const Text(
-            '내 동아리',
+            '동아리',
             style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold),
           ),
           bottom: const TabBar(
@@ -91,9 +93,9 @@ class _ClubScreenState extends State<ClubScreen> {
             labelColor: Colors.white,
             unselectedLabelColor: AppColors.subText,
             tabs: [
-              Tab(text: '정보'),
-              Tab(text: '멤버'),
               Tab(text: '순위'),
+              Tab(text: '내 동아리'),
+              Tab(text: '멤버'),
             ],
           ),
         ),
@@ -103,6 +105,10 @@ class _ClubScreenState extends State<ClubScreen> {
             Expanded(
               child: TabBarView(
                 children: [
+                  RefreshIndicator(
+                    onRefresh: _loadData,
+                    child: _buildClubRankingList(),
+                  ),
                   RefreshIndicator(
                     onRefresh: _loadData,
                     child: SingleChildScrollView(
@@ -117,10 +123,6 @@ class _ClubScreenState extends State<ClubScreen> {
                   RefreshIndicator(
                     onRefresh: _loadData,
                     child: ClubMemberList(members: _myClubMembers),
-                  ),
-                  RefreshIndicator(
-                    onRefresh: _loadData,
-                    child: _buildClubRankingList(),
                   ),
                 ],
               ),

--- a/frontend/lib/presentation/screens/club/club_screen.dart
+++ b/frontend/lib/presentation/screens/club/club_screen.dart
@@ -28,7 +28,7 @@ class _ClubScreenState extends State<ClubScreen> {
     _loadData();
   }
 
-  // 데이터 로드: 내 동아리 정보와 탐색용 동아리 목록을 가져옵니다.
+  // 데이터 로드: 내 동아리 정보, 전체 동아리 순위 목록, 멤버 목록
   Future<void> _loadData() async {
     if (!mounted) return;
     setState(() => _isLoading = true);
@@ -38,12 +38,11 @@ class _ClubScreenState extends State<ClubScreen> {
     // API 호출: 내 동아리 조회
     final myClub = await authProvider.getMyClub();
 
-    // 내 동아리가 없으면 전체 동아리 목록 조회 (탐색용)
-    List<ClubModel> allClubs = [];
+    // 전체 동아리 목록(승리 수 기준 순위) 항상 조회
+    final allClubs = await authProvider.getClubs() ?? [];
+
     List<MemberModel> myClubMembers = [];
-    if (myClub == null) {
-      allClubs = await authProvider.getClubs() ?? [];
-    } else {
+    if (myClub != null) {
       myClubMembers = await authProvider.getClubMembers(myClub.clubId) ?? [];
     }
 
@@ -65,19 +64,19 @@ class _ClubScreenState extends State<ClubScreen> {
       );
     }
 
-    // 내 동아리가 있다면 탭 뷰를 포함한 상세 화면을 보여줌
+    // 내 동아리가 있다면 탭 뷰(정보, 멤버, 순위)를 포함한 상세 화면
     if (_myClub != null) {
       return _buildMyClubDetailView(_myClub!);
     }
 
-    // 내 동아리가 없다면 동아리 탐색 목록을 보여줌
-    return _buildClubDiscoveryView();
+    // 내 동아리가 없다면 전체 동아리 순위 목록을 보여줌
+    return _buildClubRankingView();
   }
 
   // --- 1. 내 동아리 상세 뷰 (가입된 경우) ---
   Widget _buildMyClubDetailView(ClubModel club) {
     return DefaultTabController(
-      length: 2,
+      length: 3,
       child: Scaffold(
         backgroundColor: AppColors.pageBg,
         appBar: AppBar(
@@ -94,12 +93,13 @@ class _ClubScreenState extends State<ClubScreen> {
             tabs: [
               Tab(text: '정보'),
               Tab(text: '멤버'),
+              Tab(text: '순위'),
             ],
           ),
         ),
-            body: Column(
+        body: Column(
           children: [
-            ClubHeader(club: club), // 별도 구현된 위젯
+            ClubHeader(club: club),
             Expanded(
               child: TabBarView(
                 children: [
@@ -118,6 +118,10 @@ class _ClubScreenState extends State<ClubScreen> {
                     onRefresh: _loadData,
                     child: ClubMemberList(members: _myClubMembers),
                   ),
+                  RefreshIndicator(
+                    onRefresh: _loadData,
+                    child: _buildClubRankingList(),
+                  ),
                 ],
               ),
             ),
@@ -127,168 +131,135 @@ class _ClubScreenState extends State<ClubScreen> {
     );
   }
 
-  // --- 2. 동아리 탐색 뷰 (가입 안 된 경우) ---
-  Widget _buildClubDiscoveryView() {
-    final sections = [
-      _ClubSectionData(
-        title: '중앙동아리',
-        subtitle: '학교 대표 동아리',
-        accentColor: AppColors.activeBlue,
-        icon: Icons.verified,
-        clubs: _allClubs, // 실제로는 필터링 로직 추가 (e.g. .where(...) 사용)
-      ),
-      _ClubSectionData(
-        title: '과동아리',
-        subtitle: '학과 중심 동아리',
-        accentColor: Colors.teal,
-        icon: Icons.school,
-        clubs: [],
-      ),
-    ];
-
+  // --- 2. 전체 동아리 순위 뷰 (가입 안 된 경우 또는 순위 탭) ---
+  Widget _buildClubRankingView() {
     return Scaffold(
       backgroundColor: AppColors.pageBg,
       appBar: AppBar(
         backgroundColor: AppColors.headerGrey,
-        title: const Text('동아리 탐색', style: TextStyle(color: Colors.white)),
+        title: const Text('전체 동아리 순위', style: TextStyle(color: Colors.white)),
       ),
       body: RefreshIndicator(
         onRefresh: _loadData,
-        child: ListView.builder(
-          physics: const AlwaysScrollableScrollPhysics(),
-          itemCount: sections.length + 1,
-          itemBuilder: (context, index) {
-            if (index == 0) return _buildDiscoveryHeader();
-            return _ClubSection(
-              data: sections[index - 1],
-              onTapClub: (club) => Navigator.push(
-                context,
-                MaterialPageRoute(builder: (_) => ClubDetailScreen(club: club)),
-              ),
-            );
-          },
-        ),
+        child: _buildClubRankingList(),
       ),
     );
   }
 
-  Widget _buildDiscoveryHeader() {
-    return Container(
-      padding: const EdgeInsets.all(16),
-      margin: const EdgeInsets.all(12),
-      decoration: BoxDecoration(
-        color: AppColors.headerGrey.withValues(alpha: 0.1),
-        borderRadius: BorderRadius.circular(8),
-      ),
-      child: const Text(
-        '가입된 동아리가 없습니다.\n아래 카테고리에서 새로운 팀을 찾아보세요!',
-        style: TextStyle(fontWeight: FontWeight.bold),
-      ),
-    );
-  }
-}
+  Widget _buildClubRankingList() {
+    if (_allClubs.isEmpty) {
+      return const Center(
+        child: Text('등록된 동아리가 없습니다.'),
+      );
+    }
 
-// --- 보조 위젯 및 데이터 모델 ---
-
-class _ClubSectionData {
-  final String title, subtitle;
-  final Color accentColor;
-  final IconData icon;
-  final List<ClubModel> clubs;
-
-  _ClubSectionData({
-    required this.title,
-    required this.subtitle,
-    required this.accentColor,
-    required this.icon,
-    required this.clubs,
-  });
-}
-
-class _ClubSection extends StatelessWidget {
-  final _ClubSectionData data;
-  final ValueChanged<ClubModel> onTapClub;
-
-  const _ClubSection({required this.data, required this.onTapClub});
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      margin: const EdgeInsets.only(bottom: 16),
-      padding: const EdgeInsets.symmetric(vertical: 16),
-      decoration: BoxDecoration(
-        gradient: LinearGradient(
-          colors: [data.accentColor.withValues(alpha: 0.15), Colors.transparent],
-        ),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: Row(
-              children: [
-                Icon(data.icon, color: data.accentColor),
-                const SizedBox(width: 8),
-                Text(data.title, style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
-              ],
-            ),
+    return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.symmetric(vertical: 12, horizontal: 16),
+      itemCount: _allClubs.length,
+      itemBuilder: (context, index) {
+        final club = _allClubs[index];
+        return _RankedClubTile(
+          club: club,
+          onTap: () => Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => ClubDetailScreen(club: club)),
           ),
-          const SizedBox(height: 12),
-          SizedBox(
-            height: 130,
-            child: data.clubs.isEmpty
-                ? const Center(child: Text('해당 카테고리에 동아리가 없습니다.'))
-                : ListView.builder(
-              scrollDirection: Axis.horizontal,
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              itemCount: data.clubs.length,
-              itemBuilder: (context, i) => _ClubTile(
-                club: data.clubs[i],
-                color: data.accentColor,
-                onTap: () => onTapClub(data.clubs[i]),
-              ),
-            ),
-          ),
-        ],
-      ),
+        );
+      },
     );
   }
 }
 
-class _ClubTile extends StatelessWidget {
+// --- 보조 위젯 ---
+
+class _RankedClubTile extends StatelessWidget {
   final ClubModel club;
-  final Color color;
   final VoidCallback onTap;
 
-  const _ClubTile({required this.club, required this.color, required this.onTap});
+  const _RankedClubTile({required this.club, required this.onTap});
 
   @override
   Widget build(BuildContext context) {
+    final rank = club.rank > 0 ? club.rank : 0;
+    final rankColor = rank <= 3
+        ? (rank == 1
+            ? const Color(0xFFFFD700) // 금
+            : rank == 2
+                ? const Color(0xFFC0C0C0) // 은
+                : const Color(0xFFCD7F32)) // 동
+        : AppColors.subText;
+
     return GestureDetector(
       onTap: onTap,
       child: Container(
-        width: 110,
-        margin: const EdgeInsets.only(right: 12),
+        margin: const EdgeInsets.only(bottom: 8),
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
         decoration: BoxDecoration(
           color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          border: Border.all(color: color.withValues(alpha: 0.3)),
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withValues(alpha: 0.05),
+              blurRadius: 4,
+              offset: const Offset(0, 2),
+            ),
+          ],
         ),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+        child: Row(
           children: [
+            Container(
+              width: 36,
+              height: 36,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: rankColor.withValues(alpha: 0.2),
+                shape: BoxShape.circle,
+              ),
+              child: Text(
+                '$rank',
+                style: TextStyle(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 16,
+                  color: rankColor,
+                ),
+              ),
+            ),
+            const SizedBox(width: 16),
             CircleAvatar(
-              radius: 25,
-              backgroundImage: club.logoUrl != null ? NetworkImage(club.logoUrl!) : null,
-              child: club.logoUrl == null ? const Icon(Icons.group) : null,
+              radius: 24,
+              backgroundImage: club.logoUrl != null && club.logoUrl!.isNotEmpty
+                  ? NetworkImage(club.logoUrl!)
+                  : null,
+              child: club.logoUrl == null || club.logoUrl!.isEmpty
+                  ? const Icon(Icons.group, color: AppColors.subText)
+                  : null,
             ),
-            const SizedBox(height: 8),
-            Text(
-              club.name, // 모델의 name 필드 사용
-              style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 13),
-              overflow: TextOverflow.ellipsis,
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    club.name,
+                    style: const TextStyle(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 16,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    '승리 ${club.wins}승',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: AppColors.subText,
+                    ),
+                  ),
+                ],
+              ),
             ),
+            Icon(Icons.chevron_right, color: AppColors.subText),
           ],
         ),
       ),

--- a/frontend/lib/presentation/screens/matching/club_match_create_screen.dart
+++ b/frontend/lib/presentation/screens/matching/club_match_create_screen.dart
@@ -1,0 +1,269 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/club_match_provider.dart';
+import '../../providers/schedule_provider.dart';
+
+class ClubMatchCreateScreen extends StatefulWidget {
+  const ClubMatchCreateScreen({super.key});
+
+  @override
+  State<ClubMatchCreateScreen> createState() => _ClubMatchCreateScreenState();
+}
+
+class _ClubMatchCreateScreenState extends State<ClubMatchCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  DateTime? _startAt;
+  DateTime? _endAt;
+  String? _selectedLocationId;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final schedProv = context.read<ScheduleProvider>();
+      if (schedProv.locations.isEmpty) {
+        schedProv.loadSchedules();
+      }
+    });
+  }
+
+  Future<DateTime?> _pickDateTime(DateTime? initial) async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial ?? DateTime.now().add(const Duration(days: 1)),
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 90)),
+    );
+    if (date == null || !mounted) return null;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(
+          initial ?? DateTime.now().add(const Duration(hours: 1))),
+    );
+    if (time == null) return null;
+
+    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+  }
+
+  Future<void> _handleSubmit() async {
+    if (!_formKey.currentState!.validate()) return;
+    if (_startAt == null || _endAt == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('시작/종료 시각을 선택해주세요'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    if (_selectedLocationId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('장소를 선택해주세요'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    if (_startAt!.isAfter(_endAt!) || _startAt!.isAtSameMomentAs(_endAt!)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('종료 시각은 시작 시각 이후여야 합니다'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+
+    final provider = context.read<ClubMatchProvider>();
+    final fmt = DateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    final result = await provider.create(
+      startAt: fmt.format(_startAt!),
+      endAt: fmt.format(_endAt!),
+      locationId: _selectedLocationId!,
+    );
+
+    if (result != null && mounted) {
+      Navigator.pop(context, true);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('친선전이 신청되었습니다')),
+      );
+    } else if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(provider.errorMessage ?? '신청 실패'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('친선전 신청')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Row(
+                      children: [
+                        const Icon(Icons.stadium,
+                            size: 28, color: AppColors.activeBlue),
+                        const SizedBox(width: 12),
+                        Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            const Text('홈 동아리',
+                                style: TextStyle(
+                                    fontSize: 12, color: AppColors.subText)),
+                            Consumer<AuthProvider>(
+                              builder: (context, auth, _) {
+                                return FutureBuilder(
+                                  future: auth.getMyClub(),
+                                  builder: (context, snapshot) {
+                                    final club = snapshot.data;
+                                    return Text(
+                                      club?.name ?? '동아리 정보 로딩중...',
+                                      style: const TextStyle(
+                                        fontSize: 16,
+                                        fontWeight: FontWeight.bold,
+                                      ),
+                                    );
+                                  },
+                                );
+                              },
+                            ),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 16),
+                const Text(
+                  '5:5 경기를 위해 동아리 멤버 5명 이상이 참가 의사를 등록해야 합니다.',
+                  style: TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                ),
+                const SizedBox(height: 24),
+                _buildDateTimePicker(
+                  label: '시작 시각 *',
+                  value: _startAt,
+                  dateFormat: dateFormat,
+                  onTap: () async {
+                    final dt = await _pickDateTime(_startAt);
+                    if (dt != null) setState(() => _startAt = dt);
+                  },
+                ),
+                const SizedBox(height: 16),
+                _buildDateTimePicker(
+                  label: '종료 시각 *',
+                  value: _endAt,
+                  dateFormat: dateFormat,
+                  onTap: () async {
+                    final dt = await _pickDateTime(_endAt ?? _startAt);
+                    if (dt != null) setState(() => _endAt = dt);
+                  },
+                ),
+                const SizedBox(height: 16),
+                const Text('장소 *',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+                const SizedBox(height: 8),
+                Consumer<ScheduleProvider>(
+                  builder: (context, schedProv, _) {
+                    final locations = schedProv.locations;
+                    return DropdownButtonFormField<String>(
+                      value: _selectedLocationId,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        hintText: '장소 선택',
+                      ),
+                      items: locations
+                          .map((loc) => DropdownMenuItem(
+                                value: loc.id,
+                                child: Text(loc.name),
+                              ))
+                          .toList(),
+                      onChanged: (v) =>
+                          setState(() => _selectedLocationId = v),
+                      validator: (v) => v == null ? '장소를 선택해주세요' : null,
+                    );
+                  },
+                ),
+                const SizedBox(height: 32),
+                Consumer<ClubMatchProvider>(
+                  builder: (context, provider, _) {
+                    return ElevatedButton(
+                      onPressed: provider.isLoading ? null : _handleSubmit,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        backgroundColor: AppColors.activeBlue,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: provider.isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white),
+                            )
+                          : const Text('친선전 신청',
+                              style: TextStyle(fontSize: 16)),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDateTimePicker({
+    required String label,
+    required DateTime? value,
+    required DateFormat dateFormat,
+    required VoidCallback onTap,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label,
+            style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+            decoration: BoxDecoration(
+              border: Border.all(color: AppColors.border),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.calendar_today,
+                    size: 18, color: AppColors.subText),
+                const SizedBox(width: 8),
+                Text(
+                  value != null ? dateFormat.format(value) : '선택하세요',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: value != null
+                        ? AppColors.titleText
+                        : AppColors.textDisabled,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/club_match_detail_screen.dart
+++ b/frontend/lib/presentation/screens/matching/club_match_detail_screen.dart
@@ -1,0 +1,421 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../data/models/club_match_model.dart';
+import '../../providers/club_match_provider.dart';
+
+class ClubMatchDetailScreen extends StatefulWidget {
+  final String requestId;
+
+  const ClubMatchDetailScreen({super.key, required this.requestId});
+
+  @override
+  State<ClubMatchDetailScreen> createState() => _ClubMatchDetailScreenState();
+}
+
+class _ClubMatchDetailScreenState extends State<ClubMatchDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ClubMatchProvider>().loadDetail(widget.requestId);
+    });
+  }
+
+  Future<void> _handleAttend() async {
+    final provider = context.read<ClubMatchProvider>();
+    final success = await provider.attend(widget.requestId);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(success ? '참가 의사가 등록되었습니다!' : (provider.errorMessage ?? '등록 실패')),
+          backgroundColor: success ? AppColors.classTeal : Colors.red,
+        ),
+      );
+    }
+  }
+
+  void _showResultDialog() {
+    final homeController = TextEditingController();
+    final awayController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('결과 입력'),
+        content: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: homeController,
+                decoration: const InputDecoration(
+                  labelText: '홈팀',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+              ),
+            ),
+            const Padding(
+              padding: EdgeInsets.symmetric(horizontal: 12),
+              child: Text(':', style: TextStyle(fontSize: 24, fontWeight: FontWeight.bold)),
+            ),
+            Expanded(
+              child: TextField(
+                controller: awayController,
+                decoration: const InputDecoration(
+                  labelText: '원정팀',
+                  border: OutlineInputBorder(),
+                ),
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx), child: const Text('취소')),
+          ElevatedButton(
+            onPressed: () async {
+              final home = int.tryParse(homeController.text);
+              final away = int.tryParse(awayController.text);
+              if (home == null || away == null) return;
+              Navigator.pop(ctx);
+              final provider = context.read<ClubMatchProvider>();
+              await provider.submitResult(
+                widget.requestId,
+                homeScore: home,
+                awayScore: away,
+              );
+            },
+            child: const Text('제출'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleApprove() async {
+    final provider = context.read<ClubMatchProvider>();
+    final success = await provider.approveResult(widget.requestId);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(success ? '결과가 승인되었습니다!' : (provider.errorMessage ?? '승인 실패')),
+          backgroundColor: success ? AppColors.classTeal : Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('친선전 상세')),
+      body: Consumer<ClubMatchProvider>(
+        builder: (context, provider, _) {
+          final request = provider.selectedRequest;
+          if (provider.isLoading && request == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (request == null) {
+            return Center(
+              child: Text(provider.errorMessage ?? '정보를 불러올 수 없습니다',
+                  style: const TextStyle(color: AppColors.subText)),
+            );
+          }
+
+          return RefreshIndicator(
+            onRefresh: () => provider.loadDetail(widget.requestId),
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildStatusFlow(request),
+                  const SizedBox(height: 20),
+                  _buildTeams(request),
+                  const SizedBox(height: 20),
+                  _buildInfoCard(request, dateFormat),
+                  const SizedBox(height: 24),
+                  _buildActions(request),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildStatusFlow(ClubMatchRequestModel request) {
+    const steps = ['GATHERING', 'READY', 'MATCHED', 'CONFIRMED', 'DONE'];
+    const labels = ['모집중', '준비완료', '매칭완료', '확정', '완료'];
+    final currentIdx = steps.indexOf(request.status);
+
+    return SizedBox(
+      height: 60,
+      child: Row(
+        children: List.generate(steps.length, (i) {
+          final isActive = i <= currentIdx;
+          final isCurrent = i == currentIdx;
+          return Expanded(
+            child: Column(
+              children: [
+                Row(
+                  children: [
+                    if (i > 0)
+                      Expanded(
+                        child: Container(
+                          height: 2,
+                          color: isActive
+                              ? AppColors.classTeal
+                              : AppColors.border,
+                        ),
+                      ),
+                    Container(
+                      width: 24,
+                      height: 24,
+                      decoration: BoxDecoration(
+                        shape: BoxShape.circle,
+                        color: isActive
+                            ? AppColors.classTeal
+                            : AppColors.border,
+                        border: isCurrent
+                            ? Border.all(
+                                color: AppColors.classTeal, width: 3)
+                            : null,
+                      ),
+                      child: isActive
+                          ? const Icon(Icons.check,
+                              size: 14, color: Colors.white)
+                          : null,
+                    ),
+                    if (i < steps.length - 1)
+                      Expanded(
+                        child: Container(
+                          height: 2,
+                          color: i < currentIdx
+                              ? AppColors.classTeal
+                              : AppColors.border,
+                        ),
+                      ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  labels[i],
+                  style: TextStyle(
+                    fontSize: 10,
+                    color: isActive ? AppColors.classTeal : AppColors.subText,
+                    fontWeight: isCurrent ? FontWeight.bold : FontWeight.normal,
+                  ),
+                ),
+              ],
+            ),
+          );
+        }),
+      ),
+    );
+  }
+
+  Widget _buildTeams(ClubMatchRequestModel request) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: [
+            Expanded(
+              child: Column(
+                children: [
+                  CircleAvatar(
+                    radius: 30,
+                    backgroundColor: AppColors.activeBlue.withValues(alpha: 0.15),
+                    child: const Icon(Icons.stadium,
+                        size: 28, color: AppColors.activeBlue),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    request.homeClubName,
+                    style: const TextStyle(
+                        fontSize: 16, fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                  Text(
+                    '${request.homeAttendanceCount}/5명',
+                    style: TextStyle(
+                      fontSize: 13,
+                      color: request.homeAttendanceCount >= 5
+                          ? AppColors.classTeal
+                          : AppColors.alertOrange,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            const Column(
+              children: [
+                Text(
+                  'VS',
+                  style: TextStyle(
+                    fontSize: 24,
+                    fontWeight: FontWeight.bold,
+                    color: AppColors.activeBlue,
+                  ),
+                ),
+                Text('5:5',
+                    style: TextStyle(fontSize: 12, color: AppColors.subText)),
+              ],
+            ),
+            Expanded(
+              child: Column(
+                children: [
+                  CircleAvatar(
+                    radius: 30,
+                    backgroundColor: request.hasAway
+                        ? AppColors.alertOrange.withValues(alpha: 0.15)
+                        : AppColors.border.withValues(alpha: 0.3),
+                    child: Icon(
+                      request.hasAway ? Icons.stadium : Icons.help_outline,
+                      size: 28,
+                      color: request.hasAway
+                          ? AppColors.alertOrange
+                          : AppColors.textDisabled,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    request.hasAway ? request.awayClubName! : '???',
+                    style: TextStyle(
+                      fontSize: 16,
+                      fontWeight: FontWeight.bold,
+                      color: request.hasAway
+                          ? AppColors.titleText
+                          : AppColors.textDisabled,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                  if (request.hasAway)
+                    Text(
+                      '${request.awayAttendanceCount}/5명',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: request.awayAttendanceCount >= 5
+                            ? AppColors.classTeal
+                            : AppColors.alertOrange,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    )
+                  else
+                    const Text('상대 모집중',
+                        style: TextStyle(
+                            fontSize: 12, color: AppColors.textDisabled)),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoCard(
+      ClubMatchRequestModel request, DateFormat dateFormat) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            _infoRow(Icons.location_on_outlined, '장소', request.locationName),
+            const SizedBox(height: 8),
+            _infoRow(
+              Icons.access_time,
+              '시간',
+              '${dateFormat.format(request.startAt)} ~ ${DateFormat('HH:mm').format(request.endAt)}',
+            ),
+            const SizedBox(height: 8),
+            _infoRow(Icons.info_outline, '상태', request.statusDisplay),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _infoRow(IconData icon, String label, String value) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: AppColors.subText),
+        const SizedBox(width: 8),
+        Text('$label: ',
+            style: const TextStyle(fontSize: 13, color: AppColors.subText)),
+        Expanded(
+          child: Text(value,
+              style: const TextStyle(
+                  fontSize: 14, fontWeight: FontWeight.w500)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActions(ClubMatchRequestModel request) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (request.isGathering || request.isReady)
+          ElevatedButton.icon(
+            onPressed: _handleAttend,
+            icon: const Icon(Icons.how_to_reg, color: Colors.white),
+            label: const Text('참가 의사 등록',
+                style: TextStyle(fontSize: 16, color: Colors.white)),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.activeBlue,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+          ),
+        if (request.isDone) ...[
+          ElevatedButton.icon(
+            onPressed: _showResultDialog,
+            icon: const Icon(Icons.scoreboard, color: Colors.white),
+            label: const Text('결과 입력',
+                style: TextStyle(fontSize: 16, color: Colors.white)),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.classTeal,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton.icon(
+            onPressed: _handleApprove,
+            icon: const Icon(Icons.check_circle_outline),
+            label: const Text('결과 승인', style: TextStyle(fontSize: 16)),
+            style: OutlinedButton.styleFrom(
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+          ),
+        ],
+        if (request.isConfirmed)
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: AppColors.classTeal.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: const Text(
+              '경기가 확정되었습니다!',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+                color: AppColors.classTeal,
+              ),
+            ),
+          ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/club_match_list_view.dart
+++ b/frontend/lib/presentation/screens/matching/club_match_list_view.dart
@@ -1,0 +1,236 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../data/models/club_match_model.dart';
+import '../../providers/club_match_provider.dart';
+
+class ClubMatchListView extends StatefulWidget {
+  const ClubMatchListView({super.key});
+
+  @override
+  State<ClubMatchListView> createState() => _ClubMatchListViewState();
+}
+
+class _ClubMatchListViewState extends State<ClubMatchListView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<ClubMatchProvider>().loadRequests();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ClubMatchProvider>(
+      builder: (context, provider, _) {
+        if (provider.isLoading && provider.requests.isEmpty) {
+          return const Center(child: CircularProgressIndicator());
+        }
+
+        if (provider.requests.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(Icons.stadium_outlined, size: 64, color: AppColors.border),
+                const SizedBox(height: 16),
+                Text(
+                  '아직 친선전 요청이 없어요',
+                  style: TextStyle(fontSize: 16, color: AppColors.subText),
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  '동아리 대표가 친선전을 신청할 수 있습니다',
+                  style: TextStyle(fontSize: 14, color: AppColors.textDisabled),
+                ),
+              ],
+            ),
+          );
+        }
+
+        return RefreshIndicator(
+          onRefresh: provider.loadRequests,
+          child: ListView.builder(
+            padding: const EdgeInsets.all(16),
+            itemCount: provider.requests.length,
+            itemBuilder: (context, index) {
+              return _ClubMatchCard(request: provider.requests[index]);
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ClubMatchCard extends StatelessWidget {
+  final ClubMatchRequestModel request;
+
+  const _ClubMatchCard({required this.request});
+
+  Color _statusColor() {
+    switch (request.status) {
+      case 'GATHERING':
+      case 'READY':
+        return AppColors.alertOrange;
+      case 'MATCHED':
+      case 'CONFIRMED':
+        return AppColors.classTeal;
+      case 'DONE':
+        return AppColors.activeBlue;
+      case 'CANCELLED':
+        return AppColors.errorRed;
+      default:
+        return AppColors.subText;
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          Navigator.pushNamed(
+            context,
+            '/club-match-detail',
+            arguments: request.id,
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: _statusColor().withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      request.statusDisplay,
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: _statusColor(),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: AppColors.activeBlue.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: const Text(
+                      '5:5',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.activeBlue,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(
+                    child: Column(
+                      children: [
+                        Text(
+                          request.homeClubName,
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        Text(
+                          '${request.homeAttendanceCount}명',
+                          style: const TextStyle(
+                              fontSize: 12, color: AppColors.subText),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const Text(
+                    'VS',
+                    style: TextStyle(
+                      fontSize: 18,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.activeBlue,
+                    ),
+                  ),
+                  Expanded(
+                    child: Column(
+                      children: [
+                        Text(
+                          request.hasAway ? request.awayClubName! : '???',
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: request.hasAway
+                                ? AppColors.titleText
+                                : AppColors.textDisabled,
+                          ),
+                          textAlign: TextAlign.center,
+                        ),
+                        if (request.hasAway)
+                          Text(
+                            '${request.awayAttendanceCount}명',
+                            style: const TextStyle(
+                                fontSize: 12, color: AppColors.subText),
+                          )
+                        else
+                          const Text(
+                            '상대 모집중',
+                            style: TextStyle(
+                                fontSize: 12, color: AppColors.textDisabled),
+                          ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.location_on_outlined,
+                      size: 16, color: AppColors.subText),
+                  const SizedBox(width: 4),
+                  Text(
+                    request.locationName,
+                    style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                  ),
+                  const SizedBox(width: 16),
+                  const Icon(Icons.access_time,
+                      size: 16, color: AppColors.subText),
+                  const SizedBox(width: 4),
+                  Text(
+                    dateFormat.format(request.startAt),
+                    style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/matching_screen.dart
+++ b/frontend/lib/presentation/screens/matching/matching_screen.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import '../../../core/theme/app_colors.dart';
+import 'recruitment_list_view.dart';
+import 'club_match_list_view.dart';
+
+class MatchingScreen extends StatefulWidget {
+  const MatchingScreen({super.key});
+
+  @override
+  State<MatchingScreen> createState() => _MatchingScreenState();
+}
+
+class _MatchingScreenState extends State<MatchingScreen>
+    with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  void _onFabPressed() {
+    if (_tabController.index == 0) {
+      Navigator.pushNamed(context, '/recruitment-create');
+    } else {
+      Navigator.pushNamed(context, '/club-match-create');
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Row(
+          children: [
+            Icon(Icons.sports_basketball, color: AppColors.alertOrange, size: 28),
+            const SizedBox(width: 8),
+            const Text('매칭'),
+          ],
+        ),
+        bottom: TabBar(
+          controller: _tabController,
+          labelColor: AppColors.activeBlue,
+          unselectedLabelColor: AppColors.subText,
+          indicatorColor: AppColors.activeBlue,
+          tabs: const [
+            Tab(text: '게스트/번개'),
+            Tab(text: '동아리 친선전'),
+          ],
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: const [
+          RecruitmentListView(),
+          ClubMatchListView(),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        onPressed: _onFabPressed,
+        backgroundColor: AppColors.activeBlue,
+        icon: const Icon(Icons.add, color: Colors.white),
+        label: const Text('모집하기', style: TextStyle(color: Colors.white)),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
@@ -122,6 +122,30 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
       return;
     }
 
+    // 경기 형태별 최소 총원 검증 (3:3→6명, 4:4→8명, 5:5→10명)
+    final base = int.parse(_baseMembersController.text);
+    final needed = int.parse(_neededMembersController.text);
+    final total = base + needed;
+    final minTotal = switch (_gameFormat) {
+      'THREE_VS_THREE' => 6,
+      'FOUR_VS_FOUR' => 8,
+      'FIVE_VS_FIVE' => 10,
+      _ => 0, // FLEXIBLE
+    };
+    if (minTotal > 0 && total < minTotal) {
+      final formatLabel = _gameFormats.firstWhere(
+        (f) => f['value'] == _gameFormat,
+        orElse: () => {'label': ''},
+      )['label']!;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('$formatLabel 경기는 총 $minTotal명 이상이어야 합니다 (현재: $total명)'),
+          backgroundColor: Colors.red,
+        ),
+      );
+      return;
+    }
+
     final provider = context.read<RecruitmentProvider>();
     final fmt = DateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
@@ -188,7 +212,9 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
                     if (dt != null) {
                       setState(() {
                         _startAt = dt;
-                        // 시작 시간 설정 시 마감을 자동으로 30분 전으로 설정 (수동 수정 가능)
+                        // 종료 시각: 시작 + 1시간 (수동 수정 가능)
+                        _endAt = dt.add(const Duration(hours: 1));
+                        // 마감 시각: 시작 30분 전 (수동 수정 가능)
                         var deadline = dt.subtract(const Duration(minutes: 30));
                         _deadlineAt = deadline.isBefore(DateTime.now())
                             ? DateTime.now()
@@ -239,8 +265,8 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
                       child: TextFormField(
                         controller: _baseMembersController,
                         decoration: const InputDecoration(
-                          labelText: '기본 인원 *',
-                          hintText: '이미 확보된 인원',
+                          labelText: '이미 확보된 인원 *',
+                          hintText: '예: 2',
                           border: OutlineInputBorder(),
                         ),
                         keyboardType: TextInputType.number,
@@ -256,8 +282,8 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
                       child: TextFormField(
                         controller: _neededMembersController,
                         decoration: const InputDecoration(
-                          labelText: '모집 인원 *',
-                          hintText: '추가로 필요한 인원',
+                          labelText: '추가로 필요한 인원 *',
+                          hintText: '예: 4',
                           border: OutlineInputBorder(),
                         ),
                         keyboardType: TextInputType.number,

--- a/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
@@ -1,0 +1,308 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+
+import '../../providers/recruitment_provider.dart';
+import '../../providers/schedule_provider.dart';
+
+class RecruitmentCreateScreen extends StatefulWidget {
+  const RecruitmentCreateScreen({super.key});
+
+  @override
+  State<RecruitmentCreateScreen> createState() =>
+      _RecruitmentCreateScreenState();
+}
+
+class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
+  final _formKey = GlobalKey<FormState>();
+  DateTime? _startAt;
+  DateTime? _endAt;
+  DateTime? _deadlineAt;
+  String? _selectedLocationId;
+  String _gameFormat = 'FIVE_VS_FIVE';
+  final _baseMembersController = TextEditingController(text: '1');
+  final _neededMembersController = TextEditingController(text: '5');
+
+  static const _gameFormats = [
+    {'value': 'THREE_VS_THREE', 'label': '3:3'},
+    {'value': 'FOUR_VS_FOUR', 'label': '4:4'},
+    {'value': 'FIVE_VS_FIVE', 'label': '5:5'},
+    {'value': 'FLEXIBLE', 'label': '자유'},
+  ];
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final schedProv = context.read<ScheduleProvider>();
+      if (schedProv.locations.isEmpty) {
+        schedProv.loadSchedules();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _baseMembersController.dispose();
+    _neededMembersController.dispose();
+    super.dispose();
+  }
+
+  Future<DateTime?> _pickDateTime(DateTime? initial) async {
+    final date = await showDatePicker(
+      context: context,
+      initialDate: initial ?? DateTime.now().add(const Duration(hours: 1)),
+      firstDate: DateTime.now(),
+      lastDate: DateTime.now().add(const Duration(days: 90)),
+    );
+    if (date == null || !mounted) return null;
+
+    final time = await showTimePicker(
+      context: context,
+      initialTime: TimeOfDay.fromDateTime(
+          initial ?? DateTime.now().add(const Duration(hours: 1))),
+    );
+    if (time == null) return null;
+
+    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+  }
+
+  Future<void> _handleSubmit() async {
+    if (!_formKey.currentState!.validate()) return;
+    if (_startAt == null || _endAt == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('시작/종료 시각을 선택해주세요'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    if (_selectedLocationId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('장소를 선택해주세요'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+    if (_startAt!.isAfter(_endAt!) || _startAt!.isAtSameMomentAs(_endAt!)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('종료 시각은 시작 시각 이후여야 합니다'), backgroundColor: Colors.red),
+      );
+      return;
+    }
+
+    final provider = context.read<RecruitmentProvider>();
+    final fmt = DateFormat("yyyy-MM-dd'T'HH:mm:ss");
+
+    final result = await provider.create(
+      startAt: fmt.format(_startAt!),
+      endAt: fmt.format(_endAt!),
+      locationId: _selectedLocationId!,
+      baseMembersCount: int.parse(_baseMembersController.text),
+      neededMembers: int.parse(_neededMembersController.text),
+      gameFormat: _gameFormat,
+      deadlineAt: _deadlineAt != null ? fmt.format(_deadlineAt!) : null,
+    );
+
+    if (result != null && mounted) {
+      Navigator.pop(context, true);
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('모집글이 생성되었습니다')),
+      );
+    } else if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(provider.errorMessage ?? '생성 실패'),
+          backgroundColor: Colors.red,
+        ),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('모집글 작성')),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          padding: const EdgeInsets.all(24),
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                const Text('경기 형태 *',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+                const SizedBox(height: 8),
+                SegmentedButton<String>(
+                  segments: _gameFormats
+                      .map((f) => ButtonSegment(
+                            value: f['value']!,
+                            label: Text(f['label']!),
+                          ))
+                      .toList(),
+                  selected: {_gameFormat},
+                  onSelectionChanged: (v) =>
+                      setState(() => _gameFormat = v.first),
+                ),
+                const SizedBox(height: 20),
+                _buildDateTimePicker(
+                  label: '시작 시각 *',
+                  value: _startAt,
+                  dateFormat: dateFormat,
+                  onTap: () async {
+                    final dt = await _pickDateTime(_startAt);
+                    if (dt != null) setState(() => _startAt = dt);
+                  },
+                ),
+                const SizedBox(height: 16),
+                _buildDateTimePicker(
+                  label: '종료 시각 *',
+                  value: _endAt,
+                  dateFormat: dateFormat,
+                  onTap: () async {
+                    final dt = await _pickDateTime(_endAt ?? _startAt);
+                    if (dt != null) setState(() => _endAt = dt);
+                  },
+                ),
+                const SizedBox(height: 16),
+                const Text('장소 *',
+                    style: TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+                const SizedBox(height: 8),
+                Consumer<ScheduleProvider>(
+                  builder: (context, schedProv, _) {
+                    final locations = schedProv.locations;
+                    return DropdownButtonFormField<String>(
+                      value: _selectedLocationId,
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        hintText: '장소 선택',
+                      ),
+                      items: locations
+                          .map((loc) => DropdownMenuItem(
+                                value: loc.id,
+                                child: Text(loc.name),
+                              ))
+                          .toList(),
+                      onChanged: (v) =>
+                          setState(() => _selectedLocationId = v),
+                      validator: (v) => v == null ? '장소를 선택해주세요' : null,
+                    );
+                  },
+                ),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Expanded(
+                      child: TextFormField(
+                        controller: _baseMembersController,
+                        decoration: const InputDecoration(
+                          labelText: '기본 인원 *',
+                          hintText: '이미 확보된 인원',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.number,
+                        validator: (v) {
+                          final n = int.tryParse(v ?? '');
+                          if (n == null || n < 1) return '1 이상 입력';
+                          return null;
+                        },
+                      ),
+                    ),
+                    const SizedBox(width: 16),
+                    Expanded(
+                      child: TextFormField(
+                        controller: _neededMembersController,
+                        decoration: const InputDecoration(
+                          labelText: '모집 인원 *',
+                          hintText: '추가로 필요한 인원',
+                          border: OutlineInputBorder(),
+                        ),
+                        keyboardType: TextInputType.number,
+                        validator: (v) {
+                          final n = int.tryParse(v ?? '');
+                          if (n == null || n < 1) return '1 이상 입력';
+                          return null;
+                        },
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                _buildDateTimePicker(
+                  label: '마감 시각 (선택)',
+                  value: _deadlineAt,
+                  dateFormat: dateFormat,
+                  onTap: () async {
+                    final dt = await _pickDateTime(_deadlineAt ?? _startAt);
+                    if (dt != null) setState(() => _deadlineAt = dt);
+                  },
+                ),
+                const SizedBox(height: 32),
+                Consumer<RecruitmentProvider>(
+                  builder: (context, provider, _) {
+                    return ElevatedButton(
+                      onPressed: provider.isLoading ? null : _handleSubmit,
+                      style: ElevatedButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(vertical: 16),
+                        backgroundColor: AppColors.activeBlue,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: provider.isLoading
+                          ? const SizedBox(
+                              height: 20,
+                              width: 20,
+                              child: CircularProgressIndicator(
+                                  strokeWidth: 2, color: Colors.white),
+                            )
+                          : const Text('모집 시작',
+                              style: TextStyle(fontSize: 16)),
+                    );
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDateTimePicker({
+    required String label,
+    required DateTime? value,
+    required DateFormat dateFormat,
+    required VoidCallback onTap,
+  }) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(label, style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+        const SizedBox(height: 8),
+        InkWell(
+          onTap: onTap,
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 16),
+            decoration: BoxDecoration(
+              border: Border.all(color: AppColors.border),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Row(
+              children: [
+                const Icon(Icons.calendar_today, size: 18, color: AppColors.subText),
+                const SizedBox(width: 8),
+                Text(
+                  value != null ? dateFormat.format(value) : '선택하세요',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: value != null ? AppColors.titleText : AppColors.textDisabled,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_create_screen.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
@@ -49,23 +50,55 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
     super.dispose();
   }
 
+  /// 휠 스타일 날짜·시간 선택 (Cupertino 스타일, 더 직관적)
   Future<DateTime?> _pickDateTime(DateTime? initial) async {
-    final date = await showDatePicker(
-      context: context,
-      initialDate: initial ?? DateTime.now().add(const Duration(hours: 1)),
-      firstDate: DateTime.now(),
-      lastDate: DateTime.now().add(const Duration(days: 90)),
-    );
-    if (date == null || !mounted) return null;
+    var picked = initial ?? DateTime.now().add(const Duration(hours: 1));
+    if (picked.isBefore(DateTime.now())) {
+      picked = DateTime.now().add(const Duration(hours: 1));
+    }
 
-    final time = await showTimePicker(
+    final result = await showModalBottomSheet<DateTime>(
       context: context,
-      initialTime: TimeOfDay.fromDateTime(
-          initial ?? DateTime.now().add(const Duration(hours: 1))),
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (ctx) => Container(
+        height: 320,
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        child: Column(
+          children: [
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  TextButton(
+                    onPressed: () => Navigator.pop(ctx),
+                    child: const Text('취소'),
+                  ),
+                  TextButton(
+                    onPressed: () => Navigator.pop(ctx, picked),
+                    child: const Text('확인'),
+                  ),
+                ],
+              ),
+            ),
+            Expanded(
+              child: CupertinoDatePicker(
+                mode: CupertinoDatePickerMode.dateAndTime,
+                initialDateTime: picked,
+                minimumDate: DateTime.now(),
+                maximumDate: DateTime.now().add(const Duration(days: 90)),
+                onDateTimeChanged: (dt) => picked = dt,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
-    if (time == null) return null;
-
-    return DateTime(date.year, date.month, date.day, time.hour, time.minute);
+    return result;
   }
 
   Future<void> _handleSubmit() async {
@@ -152,7 +185,16 @@ class _RecruitmentCreateScreenState extends State<RecruitmentCreateScreen> {
                   dateFormat: dateFormat,
                   onTap: () async {
                     final dt = await _pickDateTime(_startAt);
-                    if (dt != null) setState(() => _startAt = dt);
+                    if (dt != null) {
+                      setState(() {
+                        _startAt = dt;
+                        // 시작 시간 설정 시 마감을 자동으로 30분 전으로 설정 (수동 수정 가능)
+                        var deadline = dt.subtract(const Duration(minutes: 30));
+                        _deadlineAt = deadline.isBefore(DateTime.now())
+                            ? DateTime.now()
+                            : deadline;
+                      });
+                    }
                   },
                 ),
                 const SizedBox(height: 16),

--- a/frontend/lib/presentation/screens/matching/recruitment_detail_screen.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_detail_screen.dart
@@ -169,9 +169,8 @@ class _RecruitmentDetailScreenState extends State<RecruitmentDetailScreen> {
                   _buildInfoSection(detail, dateFormat),
                   const SizedBox(height: 20),
                   ProgressBarWidget(
-                    current: detail.acceptedCount,
-                    total: detail.neededMembers,
-                    baseCount: detail.baseMembersCount,
+                    currentCount: detail.currentCount,
+                    totalNeeded: detail.totalNeeded,
                   ),
                   const SizedBox(height: 24),
                   if (isAuthor && detail.isOpen) ...[

--- a/frontend/lib/presentation/screens/matching/recruitment_detail_screen.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_detail_screen.dart
@@ -1,0 +1,388 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../data/models/recruitment_model.dart';
+import '../../providers/auth_provider.dart';
+import '../../providers/recruitment_provider.dart';
+import 'widgets/progress_bar_widget.dart';
+import 'widgets/applicant_card.dart';
+
+class RecruitmentDetailScreen extends StatefulWidget {
+  final String recruitmentId;
+
+  const RecruitmentDetailScreen({super.key, required this.recruitmentId});
+
+  @override
+  State<RecruitmentDetailScreen> createState() =>
+      _RecruitmentDetailScreenState();
+}
+
+class _RecruitmentDetailScreenState extends State<RecruitmentDetailScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RecruitmentProvider>().loadDetail(widget.recruitmentId);
+    });
+  }
+
+  void _showApplyDialog() {
+    final messageController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('신청하기'),
+        content: TextField(
+          controller: messageController,
+          decoration: const InputDecoration(
+            hintText: '한줄 메시지 (선택)',
+            border: OutlineInputBorder(),
+          ),
+          maxLength: 200,
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(ctx),
+            child: const Text('취소'),
+          ),
+          ElevatedButton(
+            onPressed: () async {
+              Navigator.pop(ctx);
+              final provider = context.read<RecruitmentProvider>();
+              final success = await provider.apply(
+                widget.recruitmentId,
+                message: messageController.text.trim().isEmpty
+                    ? null
+                    : messageController.text.trim(),
+              );
+              if (mounted) {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text(success ? '신청 완료!' : (provider.errorMessage ?? '신청 실패')),
+                    backgroundColor: success ? AppColors.classTeal : Colors.red,
+                  ),
+                );
+              }
+            },
+            child: const Text('신청'),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _handleConfirm() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('모집 확정'),
+        content: const Text('모집을 확정하고 경기를 생성할까요?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('취소')),
+          ElevatedButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('확정')),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final provider = context.read<RecruitmentProvider>();
+    final success = await provider.confirm(widget.recruitmentId);
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(success ? '모집이 확정되었습니다!' : (provider.errorMessage ?? '확정 실패')),
+          backgroundColor: success ? AppColors.classTeal : Colors.red,
+        ),
+      );
+    }
+  }
+
+  Future<void> _handleCancel() async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('모집 취소'),
+        content: const Text('정말 모집을 취소할까요?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('아니오')),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(ctx, true),
+            style: ElevatedButton.styleFrom(backgroundColor: AppColors.errorRed),
+            child: const Text('취소하기', style: TextStyle(color: Colors.white)),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    final provider = context.read<RecruitmentProvider>();
+    final success = await provider.cancel(widget.recruitmentId);
+    if (mounted) {
+      if (success) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('모집이 취소되었습니다')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(provider.errorMessage ?? '취소 실패'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final currentUser = context.read<AuthProvider>().currentUser;
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('모집 상세')),
+      body: Consumer<RecruitmentProvider>(
+        builder: (context, provider, _) {
+          final detail = provider.selectedRecruitment;
+          if (provider.isLoading && detail == null) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (detail == null) {
+            return Center(
+              child: Text(provider.errorMessage ?? '모집글을 불러올 수 없습니다',
+                  style: const TextStyle(color: AppColors.subText)),
+            );
+          }
+
+          final isAuthor = currentUser?.userId == detail.authorId;
+
+          return RefreshIndicator(
+            onRefresh: () => provider.loadDetail(widget.recruitmentId),
+            child: SingleChildScrollView(
+              physics: const AlwaysScrollableScrollPhysics(),
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _buildInfoSection(detail, dateFormat),
+                  const SizedBox(height: 20),
+                  ProgressBarWidget(
+                    current: detail.acceptedCount,
+                    total: detail.neededMembers,
+                    baseCount: detail.baseMembersCount,
+                  ),
+                  const SizedBox(height: 24),
+                  if (isAuthor && detail.isOpen) ...[
+                    _buildApplicationsSection(detail, provider),
+                    const SizedBox(height: 24),
+                    _buildAuthorActions(detail),
+                  ] else if (!isAuthor && detail.isOpen) ...[
+                    _buildApplyButton(),
+                  ],
+                  if (!detail.isOpen) ...[
+                    _buildStatusBanner(detail),
+                  ],
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildInfoSection(RecruitmentDetailModel detail, DateFormat dateFormat) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: AppColors.activeBlue.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    detail.gameFormatDisplay,
+                    style: const TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.bold,
+                      color: AppColors.activeBlue,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                  decoration: BoxDecoration(
+                    color: detail.isOpen
+                        ? AppColors.classTeal.withValues(alpha: 0.1)
+                        : AppColors.subText.withValues(alpha: 0.1),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Text(
+                    detail.statusDisplay,
+                    style: TextStyle(
+                      fontSize: 13,
+                      fontWeight: FontWeight.bold,
+                      color: detail.isOpen ? AppColors.classTeal : AppColors.subText,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            _infoRow(Icons.person_outline, '모집자', detail.authorNickname),
+            const SizedBox(height: 8),
+            _infoRow(Icons.location_on_outlined, '장소', detail.locationName),
+            const SizedBox(height: 8),
+            _infoRow(
+              Icons.access_time,
+              '시간',
+              '${dateFormat.format(detail.startAt)} ~ ${DateFormat('HH:mm').format(detail.endAt)}',
+            ),
+            if (detail.deadlineAt != null) ...[
+              const SizedBox(height: 8),
+              _infoRow(
+                Icons.timer_outlined,
+                '마감',
+                dateFormat.format(detail.deadlineAt!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _infoRow(IconData icon, String label, String value) {
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: AppColors.subText),
+        const SizedBox(width: 8),
+        Text('$label: ', style: const TextStyle(fontSize: 13, color: AppColors.subText)),
+        Expanded(
+          child: Text(value,
+              style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500)),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildApplicationsSection(
+      RecruitmentDetailModel detail, RecruitmentProvider provider) {
+    final pending =
+        detail.applications.where((a) => a.isPending).toList();
+    final accepted =
+        detail.applications.where((a) => a.isAccepted).toList();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          '신청 목록 (${detail.applications.length})',
+          style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 12),
+        if (pending.isNotEmpty) ...[
+          const Text('대기중', style: TextStyle(fontSize: 13, color: AppColors.alertOrange, fontWeight: FontWeight.w600)),
+          const SizedBox(height: 8),
+          ...pending.map((app) => ApplicantCard(
+                application: app,
+                onAccept: () => provider.acceptApplication(
+                    detail.id, app.applicationId),
+                onReject: () => provider.rejectApplication(
+                    detail.id, app.applicationId),
+              )),
+        ],
+        if (accepted.isNotEmpty) ...[
+          const SizedBox(height: 12),
+          const Text('수락됨', style: TextStyle(fontSize: 13, color: AppColors.classTeal, fontWeight: FontWeight.w600)),
+          const SizedBox(height: 8),
+          ...accepted.map((app) => ApplicantCard(
+                application: app,
+                showActions: false,
+              )),
+        ],
+      ],
+    );
+  }
+
+  Widget _buildAuthorActions(RecruitmentDetailModel detail) {
+    return Row(
+      children: [
+        Expanded(
+          child: OutlinedButton(
+            onPressed: _handleCancel,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: AppColors.errorRed,
+              side: const BorderSide(color: AppColors.errorRed),
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+            child: const Text('취소하기'),
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          flex: 2,
+          child: ElevatedButton(
+            onPressed: _handleConfirm,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: AppColors.classTeal,
+              foregroundColor: Colors.white,
+              padding: const EdgeInsets.symmetric(vertical: 14),
+            ),
+            child: const Text('확정하기'),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildApplyButton() {
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
+        onPressed: _showApplyDialog,
+        icon: const Icon(Icons.person_add, color: Colors.white),
+        label: const Text('신청하기', style: TextStyle(fontSize: 16, color: Colors.white)),
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.activeBlue,
+          padding: const EdgeInsets.symmetric(vertical: 14),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStatusBanner(RecruitmentDetailModel detail) {
+    final color = detail.status == 'CONFIRMED'
+        ? AppColors.classTeal
+        : detail.status == 'CANCELLED'
+            ? AppColors.errorRed
+            : AppColors.subText;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      child: Text(
+        detail.statusDisplay,
+        textAlign: TextAlign.center,
+        style: TextStyle(
+          fontSize: 16,
+          fontWeight: FontWeight.bold,
+          color: color,
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/recruitment_list_view.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_list_view.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../data/models/recruitment_model.dart';
+import '../../providers/recruitment_provider.dart';
+import 'widgets/progress_bar_widget.dart';
+
+class RecruitmentListView extends StatefulWidget {
+  const RecruitmentListView({super.key});
+
+  @override
+  State<RecruitmentListView> createState() => _RecruitmentListViewState();
+}
+
+class _RecruitmentListViewState extends State<RecruitmentListView> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<RecruitmentProvider>().loadRecruitments();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<RecruitmentProvider>(
+      builder: (context, provider, _) {
+        return Column(
+          children: [
+            _buildFilterChips(provider),
+            Expanded(
+              child: provider.isLoading && provider.recruitments.isEmpty
+                  ? const Center(child: CircularProgressIndicator())
+                  : provider.recruitments.isEmpty
+                      ? _buildEmptyState()
+                      : RefreshIndicator(
+                          onRefresh: provider.loadRecruitments,
+                          child: ListView.builder(
+                            padding: const EdgeInsets.all(16),
+                            itemCount: provider.recruitments.length,
+                            itemBuilder: (context, index) {
+                              return _RecruitmentCard(
+                                recruitment: provider.recruitments[index],
+                              );
+                            },
+                          ),
+                        ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildFilterChips(RecruitmentProvider provider) {
+    return Container(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.border.withValues(alpha: 0.3),
+            spreadRadius: 1,
+            blurRadius: 3,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 16),
+        child: Row(
+          children: [
+            _FilterChipItem(
+              label: '전체',
+              isActive: provider.filterGameFormat == null,
+              onTap: () => provider.setFilter(
+                gameFormat: null,
+                status: provider.filterStatus,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _FilterChipItem(
+              label: '3:3',
+              isActive: provider.filterGameFormat == 'THREE_VS_THREE',
+              onTap: () => provider.setFilter(
+                gameFormat: 'THREE_VS_THREE',
+                status: provider.filterStatus,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _FilterChipItem(
+              label: '4:4',
+              isActive: provider.filterGameFormat == 'FOUR_VS_FOUR',
+              onTap: () => provider.setFilter(
+                gameFormat: 'FOUR_VS_FOUR',
+                status: provider.filterStatus,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _FilterChipItem(
+              label: '5:5',
+              isActive: provider.filterGameFormat == 'FIVE_VS_FIVE',
+              onTap: () => provider.setFilter(
+                gameFormat: 'FIVE_VS_FIVE',
+                status: provider.filterStatus,
+              ),
+            ),
+            const SizedBox(width: 8),
+            _FilterChipItem(
+              label: '자유',
+              isActive: provider.filterGameFormat == 'FLEXIBLE',
+              onTap: () => provider.setFilter(
+                gameFormat: 'FLEXIBLE',
+                status: provider.filterStatus,
+              ),
+            ),
+            const SizedBox(width: 16),
+            _FilterChipItem(
+              label: '모집중만',
+              icon: Icons.circle,
+              isActive: provider.filterStatus == 'OPEN',
+              onTap: () => provider.setFilter(
+                status: provider.filterStatus == 'OPEN' ? null : 'OPEN',
+                gameFormat: provider.filterGameFormat,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(Icons.sports_basketball_outlined,
+              size: 64, color: AppColors.border),
+          const SizedBox(height: 16),
+          Text(
+            '아직 모집글이 없어요',
+            style: TextStyle(fontSize: 16, color: AppColors.subText),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'FAB 버튼을 눌러 모집을 시작해보세요!',
+            style: TextStyle(fontSize: 14, color: AppColors.textDisabled),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _FilterChipItem extends StatelessWidget {
+  final String label;
+  final IconData? icon;
+  final bool isActive;
+  final VoidCallback onTap;
+
+  const _FilterChipItem({
+    required this.label,
+    this.icon,
+    required this.isActive,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterChip(
+      label: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, size: 10,
+                color: isActive ? Colors.white : AppColors.classTeal),
+            const SizedBox(width: 4),
+          ],
+          Text(label),
+        ],
+      ),
+      selected: isActive,
+      onSelected: (_) => onTap(),
+      backgroundColor: Colors.white,
+      selectedColor: AppColors.activeBlue,
+      labelStyle: TextStyle(
+        color: isActive ? Colors.white : AppColors.titleText,
+        fontSize: 12,
+      ),
+      side: BorderSide(color: isActive ? AppColors.activeBlue : AppColors.border),
+    );
+  }
+}
+
+class _RecruitmentCard extends StatelessWidget {
+  final RecruitmentListModel recruitment;
+
+  const _RecruitmentCard({required this.recruitment});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat('M/d(E) HH:mm', 'ko');
+
+    return Card(
+      margin: const EdgeInsets.only(bottom: 12),
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(12),
+        onTap: () {
+          Navigator.pushNamed(
+            context,
+            '/recruitment-detail',
+            arguments: recruitment.id,
+          );
+        },
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: AppColors.activeBlue.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      recruitment.gameFormatDisplay,
+                      style: const TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.activeBlue,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Container(
+                    padding:
+                        const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: recruitment.isOpen
+                          ? AppColors.classTeal.withValues(alpha: 0.1)
+                          : AppColors.subText.withValues(alpha: 0.1),
+                      borderRadius: BorderRadius.circular(6),
+                    ),
+                    child: Text(
+                      recruitment.statusDisplay,
+                      style: TextStyle(
+                        fontSize: 11,
+                        fontWeight: FontWeight.bold,
+                        color: recruitment.isOpen
+                            ? AppColors.classTeal
+                            : AppColors.subText,
+                      ),
+                    ),
+                  ),
+                  if (recruitment.isFull) ...[
+                    const SizedBox(width: 8),
+                    Container(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      decoration: BoxDecoration(
+                        color: AppColors.alertOrange.withValues(alpha: 0.1),
+                        borderRadius: BorderRadius.circular(6),
+                      ),
+                      child: const Text(
+                        'FULL',
+                        style: TextStyle(
+                          fontSize: 11,
+                          fontWeight: FontWeight.bold,
+                          color: AppColors.alertOrange,
+                        ),
+                      ),
+                    ),
+                  ],
+                  const Spacer(),
+                  Text(
+                    recruitment.authorNickname,
+                    style: const TextStyle(
+                        fontSize: 12, color: AppColors.subText),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  const Icon(Icons.location_on_outlined,
+                      size: 16, color: AppColors.subText),
+                  const SizedBox(width: 4),
+                  Text(
+                    recruitment.locationName,
+                    style: const TextStyle(fontSize: 14, fontWeight: FontWeight.w500),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  const Icon(Icons.access_time,
+                      size: 16, color: AppColors.subText),
+                  const SizedBox(width: 4),
+                  Text(
+                    '${dateFormat.format(recruitment.startAt)} ~ ${DateFormat('HH:mm').format(recruitment.endAt)}',
+                    style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+              ProgressBarWidget(
+                current: recruitment.acceptedCount,
+                total: recruitment.neededMembers,
+                baseCount: recruitment.baseMembersCount,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/recruitment_list_view.dart
+++ b/frontend/lib/presentation/screens/matching/recruitment_list_view.dart
@@ -314,9 +314,8 @@ class _RecruitmentCard extends StatelessWidget {
               ),
               const SizedBox(height: 12),
               ProgressBarWidget(
-                current: recruitment.acceptedCount,
-                total: recruitment.neededMembers,
-                baseCount: recruitment.baseMembersCount,
+                currentCount: recruitment.currentCount,
+                totalNeeded: recruitment.totalNeeded,
               ),
             ],
           ),

--- a/frontend/lib/presentation/screens/matching/review_bottom_sheet.dart
+++ b/frontend/lib/presentation/screens/matching/review_bottom_sheet.dart
@@ -1,0 +1,258 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../../../core/theme/app_colors.dart';
+import '../../../data/models/match_model.dart';
+import '../../providers/match_provider.dart';
+
+class ReviewBottomSheet extends StatefulWidget {
+  final String matchId;
+
+  const ReviewBottomSheet({super.key, required this.matchId});
+
+  static Future<void> show(BuildContext context, String matchId) async {
+    await showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (_) => ChangeNotifierProvider.value(
+        value: context.read<MatchProvider>(),
+        child: ReviewBottomSheet(matchId: matchId),
+      ),
+    );
+  }
+
+  @override
+  State<ReviewBottomSheet> createState() => _ReviewBottomSheetState();
+}
+
+class _ReviewBottomSheetState extends State<ReviewBottomSheet> {
+  final Set<int> _thumbsUpIds = {};
+  final Set<int> _noShowIds = {};
+  bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<MatchProvider>().loadReviewForm(widget.matchId);
+    });
+  }
+
+  Future<void> _handleSubmit() async {
+    setState(() => _submitting = true);
+    final provider = context.read<MatchProvider>();
+    final success = await provider.submitReview(
+      widget.matchId,
+      thumbsUpUserIds: _thumbsUpIds.toList(),
+      noShowUserIds: _noShowIds.toList(),
+    );
+    setState(() => _submitting = false);
+
+    if (mounted) {
+      if (success) {
+        Navigator.pop(context);
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('리뷰가 제출되었습니다!')),
+        );
+      } else {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(provider.errorMessage ?? '제출 실패'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MatchProvider>(
+      builder: (context, provider, _) {
+        final form = provider.reviewForm;
+
+        return DraggableScrollableSheet(
+          initialChildSize: 0.7,
+          maxChildSize: 0.9,
+          minChildSize: 0.4,
+          expand: false,
+          builder: (context, scrollController) {
+            if (provider.isLoading || form == null) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (form.alreadySubmitted) {
+              return Padding(
+                padding: const EdgeInsets.all(32),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.check_circle,
+                        size: 64, color: AppColors.classTeal),
+                    const SizedBox(height: 16),
+                    const Text('이미 리뷰를 제출했습니다',
+                        style: TextStyle(
+                            fontSize: 16, fontWeight: FontWeight.bold)),
+                    const SizedBox(height: 24),
+                    ElevatedButton(
+                      onPressed: () => Navigator.pop(context),
+                      child: const Text('닫기'),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return ListView(
+              controller: scrollController,
+              padding: const EdgeInsets.all(20),
+              children: [
+                Center(
+                  child: Container(
+                    width: 40,
+                    height: 4,
+                    margin: const EdgeInsets.only(bottom: 16),
+                    decoration: BoxDecoration(
+                      color: AppColors.border,
+                      borderRadius: BorderRadius.circular(2),
+                    ),
+                  ),
+                ),
+                const Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(Icons.sports_basketball,
+                        color: AppColors.alertOrange, size: 24),
+                    SizedBox(width: 8),
+                    Text(
+                      '경기가 끝났어요!',
+                      style: TextStyle(
+                          fontSize: 18, fontWeight: FontWeight.bold),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  '${form.locationName}',
+                  textAlign: TextAlign.center,
+                  style: const TextStyle(
+                      fontSize: 13, color: AppColors.subText),
+                ),
+                const SizedBox(height: 20),
+                const Text(
+                  '함께한 사람들을 평가해주세요',
+                  style: TextStyle(
+                      fontSize: 14, color: AppColors.textSecondary),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 16),
+                ...form.participants.map((p) => _buildParticipantRow(p)),
+                const SizedBox(height: 24),
+                ElevatedButton(
+                  onPressed: _submitting ? null : _handleSubmit,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: AppColors.activeBlue,
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                  ),
+                  child: _submitting
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(
+                              strokeWidth: 2, color: Colors.white),
+                        )
+                      : const Text('제출하기', style: TextStyle(fontSize: 16)),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildParticipantRow(ParticipantModel participant) {
+    final hasThumbsUp = _thumbsUpIds.contains(participant.userId);
+    final hasNoShow = _noShowIds.contains(participant.userId);
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: AppColors.backgroundWhite,
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: AppColors.border),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 18,
+            backgroundColor: AppColors.activeBlue.withValues(alpha: 0.15),
+            child: Text(
+              participant.nickname.isNotEmpty ? participant.nickname[0] : '?',
+              style: const TextStyle(
+                  fontWeight: FontWeight.bold, color: AppColors.activeBlue),
+            ),
+          ),
+          const SizedBox(width: 10),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  participant.nickname,
+                  style: const TextStyle(
+                      fontSize: 14, fontWeight: FontWeight.w600),
+                ),
+                if (participant.position != null)
+                  Text(
+                    participant.positionDisplay,
+                    style: const TextStyle(
+                        fontSize: 12, color: AppColors.subText),
+                  ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() {
+                if (hasThumbsUp) {
+                  _thumbsUpIds.remove(participant.userId);
+                } else {
+                  _thumbsUpIds.add(participant.userId);
+                  _noShowIds.remove(participant.userId);
+                }
+              });
+            },
+            icon: Icon(
+              hasThumbsUp ? Icons.thumb_up : Icons.thumb_up_outlined,
+              color: hasThumbsUp ? AppColors.activeBlue : AppColors.subText,
+              size: 22,
+            ),
+          ),
+          IconButton(
+            onPressed: () {
+              setState(() {
+                if (hasNoShow) {
+                  _noShowIds.remove(participant.userId);
+                } else {
+                  _noShowIds.add(participant.userId);
+                  _thumbsUpIds.remove(participant.userId);
+                }
+              });
+            },
+            icon: Icon(
+              hasNoShow ? Icons.warning : Icons.warning_amber_outlined,
+              color: hasNoShow ? AppColors.errorRed : AppColors.subText,
+              size: 22,
+            ),
+            tooltip: '노쇼 신고',
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/widgets/applicant_card.dart
+++ b/frontend/lib/presentation/screens/matching/widgets/applicant_card.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../data/models/recruitment_model.dart';
+
+class ApplicantCard extends StatelessWidget {
+  final ApplicationModel application;
+  final VoidCallback? onAccept;
+  final VoidCallback? onReject;
+  final bool showActions;
+
+  const ApplicantCard({
+    super.key,
+    required this.application,
+    this.onAccept,
+    this.onReject,
+    this.showActions = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.only(bottom: 8),
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(10),
+        side: BorderSide(color: AppColors.border),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 18,
+                  backgroundColor: AppColors.activeBlue.withValues(alpha: 0.15),
+                  child: Text(
+                    application.applicantNickname.isNotEmpty
+                        ? application.applicantNickname[0]
+                        : '?',
+                    style: const TextStyle(
+                        fontWeight: FontWeight.bold,
+                        color: AppColors.activeBlue),
+                  ),
+                ),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        application.applicantNickname,
+                        style: const TextStyle(
+                            fontSize: 14, fontWeight: FontWeight.w600),
+                      ),
+                      const SizedBox(height: 2),
+                      Row(
+                        children: [
+                          _tag(application.positionDisplay),
+                          const SizedBox(width: 6),
+                          _tag('EXP ${application.applicantExp}'),
+                          if (application.applicantNoShowCount > 0) ...[
+                            const SizedBox(width: 6),
+                            _tag(
+                              '노쇼 ${application.applicantNoShowCount}',
+                              color: AppColors.errorRed,
+                            ),
+                          ],
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+                if (application.isAccepted)
+                  const Icon(Icons.check_circle, color: AppColors.classTeal, size: 22),
+                if (application.isRejected)
+                  const Icon(Icons.cancel, color: AppColors.errorRed, size: 22),
+              ],
+            ),
+            if (application.message != null &&
+                application.message!.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: AppColors.pageBg,
+                  borderRadius: BorderRadius.circular(6),
+                ),
+                child: Text(
+                  application.message!,
+                  style: const TextStyle(fontSize: 13, color: AppColors.textSecondary),
+                ),
+              ),
+            ],
+            if (showActions && application.isPending) ...[
+              const SizedBox(height: 10),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  OutlinedButton(
+                    onPressed: onReject,
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.errorRed,
+                      side: const BorderSide(color: AppColors.errorRed),
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 6),
+                    ),
+                    child: const Text('거절', style: TextStyle(fontSize: 13)),
+                  ),
+                  const SizedBox(width: 8),
+                  ElevatedButton(
+                    onPressed: onAccept,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: AppColors.classTeal,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 6),
+                    ),
+                    child: const Text('수락', style: TextStyle(fontSize: 13)),
+                  ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _tag(String text, {Color? color}) {
+    final c = color ?? AppColors.subText;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+      decoration: BoxDecoration(
+        color: c.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(4),
+      ),
+      child: Text(
+        text,
+        style: TextStyle(fontSize: 11, color: c, fontWeight: FontWeight.w500),
+      ),
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/matching/widgets/progress_bar_widget.dart
+++ b/frontend/lib/presentation/screens/matching/widgets/progress_bar_widget.dart
@@ -1,24 +1,22 @@
 import 'package:flutter/material.dart';
 import '../../../../core/theme/app_colors.dart';
 
+/// 모집 인원 진행률: currentCount = 현재 인원, totalNeeded = 총 필요 인원
 class ProgressBarWidget extends StatelessWidget {
-  final int current;
-  final int total;
-  final int baseCount;
+  final int currentCount;
+  final int totalNeeded;
 
   const ProgressBarWidget({
     super.key,
-    required this.current,
-    required this.total,
-    required this.baseCount,
+    required this.currentCount,
+    required this.totalNeeded,
   });
 
   @override
   Widget build(BuildContext context) {
-    final filled = baseCount + current;
-    final max = baseCount + total;
-    final ratio = total > 0 ? (current / total).clamp(0.0, 1.0) : 0.0;
-    final isFull = current >= total;
+    final remaining = totalNeeded - currentCount;
+    final ratio = totalNeeded > 0 ? (currentCount / totalNeeded).clamp(0.0, 1.0) : 0.0;
+    final isFull = remaining <= 0;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -27,7 +25,7 @@ class ProgressBarWidget extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             Text(
-              '현재 $filled / $max명',
+              '현재 $currentCount / $totalNeeded명',
               style: const TextStyle(
                 fontSize: 13,
                 fontWeight: FontWeight.w600,
@@ -35,7 +33,7 @@ class ProgressBarWidget extends StatelessWidget {
               ),
             ),
             Text(
-              isFull ? '모집 완료!' : '$current명 더 모이면 확정!',
+              isFull ? '모집 완료!' : '$remaining명 더 모이면 확정!',
               style: TextStyle(
                 fontSize: 12,
                 color: isFull ? AppColors.classTeal : AppColors.subText,

--- a/frontend/lib/presentation/screens/matching/widgets/progress_bar_widget.dart
+++ b/frontend/lib/presentation/screens/matching/widgets/progress_bar_widget.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+
+class ProgressBarWidget extends StatelessWidget {
+  final int current;
+  final int total;
+  final int baseCount;
+
+  const ProgressBarWidget({
+    super.key,
+    required this.current,
+    required this.total,
+    required this.baseCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final filled = baseCount + current;
+    final max = baseCount + total;
+    final ratio = total > 0 ? (current / total).clamp(0.0, 1.0) : 0.0;
+    final isFull = current >= total;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              '현재 $filled / $max명',
+              style: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+                color: AppColors.titleText,
+              ),
+            ),
+            Text(
+              isFull ? '모집 완료!' : '$current명 더 모이면 확정!',
+              style: TextStyle(
+                fontSize: 12,
+                color: isFull ? AppColors.classTeal : AppColors.subText,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 6),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(4),
+          child: LinearProgressIndicator(
+            value: ratio,
+            minHeight: 8,
+            backgroundColor: AppColors.border,
+            valueColor: AlwaysStoppedAnimation<Color>(
+              isFull ? AppColors.classTeal : AppColors.activeBlue,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/frontend/lib/presentation/screens/root/root_screen.dart
+++ b/frontend/lib/presentation/screens/root/root_screen.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../core/theme/app_colors.dart';
 import '../club/club_screen.dart';
 import '../community/community_screen.dart';
-import '../home/home_screen.dart';
+import '../matching/matching_screen.dart';
 import '../schedule/schedule_screen.dart';
 import '../user/user_tab.dart';
 
@@ -23,7 +23,7 @@ class _RootScreenState extends State<RootScreen> {
   late int _selectedIndex;
 
   late final List<Widget> _screens = const [
-    HomeScreen(),
+    MatchingScreen(),
     ClubScreen(),
     CommunityScreen(),
     ScheduleScreen(),
@@ -52,9 +52,9 @@ class _RootScreenState extends State<RootScreen> {
         },
         items: const [
           BottomNavigationBarItem(
-            icon: Icon(Icons.home_outlined),
-            activeIcon: Icon(Icons.home),
-            label: '홈',
+            icon: Icon(Icons.sports_basketball_outlined),
+            activeIcon: Icon(Icons.sports_basketball),
+            label: '매칭',
           ),
           BottomNavigationBarItem(
             icon: Icon(Icons.stadium_outlined),

--- a/frontend/lib/presentation/screens/schedule/schedule_screen.dart
+++ b/frontend/lib/presentation/screens/schedule/schedule_screen.dart
@@ -370,51 +370,67 @@ class _ScheduleScreenState extends State<ScheduleScreen> {
   ) {
     final locationColor = _colorForLocation(schedule.locationId, provider.locations);
 
+    final isMatch = schedule.matchId != null && schedule.matchId!.isNotEmpty;
+
     return Positioned(
       left: 2,
       right: 2,
       top: top + 2,
-      child: Container(
-        height: height.clamp(24, double.infinity) - 4,
-        padding: const EdgeInsets.all(4),
-        decoration: BoxDecoration(
-          color: locationColor.withValues(alpha: 0.2),
-          borderRadius: BorderRadius.circular(4),
-          border: Border(
-            left: BorderSide(color: locationColor, width: 3),
+      child: GestureDetector(
+        onTap: isMatch
+            ? () {
+                Navigator.pushNamed(
+                  context,
+                  '/recruitment-detail',
+                  arguments: schedule.matchId,
+                );
+              }
+            : null,
+        child: Container(
+          height: height.clamp(24, double.infinity) - 4,
+          padding: const EdgeInsets.all(4),
+          decoration: BoxDecoration(
+            color: locationColor.withValues(alpha: 0.2),
+            borderRadius: BorderRadius.circular(4),
+            border: Border(
+              left: BorderSide(color: locationColor, width: 3),
+            ),
           ),
-        ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            FittedBox(
-              alignment: Alignment.centerLeft,
-              fit: BoxFit.scaleDown,
-              child: Text(
-                schedule.locationName,
-                style: const TextStyle(
-                  fontSize: 9,
-                  fontWeight: FontWeight.w600,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              if (isMatch)
+                const Icon(Icons.sports_basketball, size: 10, color: AppColors.alertOrange),
+              FittedBox(
+                alignment: Alignment.centerLeft,
+                fit: BoxFit.scaleDown,
+                child: Text(
+                  schedule.title ?? schedule.locationName,
+                  style: TextStyle(
+                    fontSize: 9,
+                    fontWeight: FontWeight.w600,
+                    color: isMatch ? AppColors.activeBlue : null,
+                  ),
                 ),
               ),
-            ),
-            Text(
-              '${schedule.startTime}~${schedule.endTime}',
-              style: TextStyle(
-                fontSize: 8,
-                color: AppColors.subText,
+              Text(
+                '${schedule.startTime}~${schedule.endTime}',
+                style: TextStyle(
+                  fontSize: 8,
+                  color: AppColors.subText,
+                ),
               ),
-            ),
-            Text(
-              schedule.statusDisplayText,
-              style: TextStyle(
-                fontSize: 8,
-                color: locationColor,
-                fontWeight: FontWeight.w500,
+              Text(
+                isMatch ? '매칭' : schedule.statusDisplayText,
+                style: TextStyle(
+                  fontSize: 8,
+                  color: isMatch ? AppColors.activeBlue : locationColor,
+                  fontWeight: FontWeight.w500,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );

--- a/frontend/lib/presentation/widgets/user/profile_header.dart
+++ b/frontend/lib/presentation/widgets/user/profile_header.dart
@@ -48,13 +48,23 @@ class ProfileHeader extends StatelessWidget {
           ),
           const SizedBox(height: 16),
           Text(
-            user.realName,
+            user.nickname ?? user.realName,
             style: const TextStyle(
               fontSize: 18,
               fontWeight: FontWeight.bold,
               color: AppColors.titleText,
             ),
           ),
+          if (user.nickname != null) ...[
+            const SizedBox(height: 4),
+            Text(
+              user.realName,
+              style: const TextStyle(
+                fontSize: 13,
+                color: AppColors.subText,
+              ),
+            ),
+          ],
           const SizedBox(height: 8),
           Text(
             user.email,
@@ -64,24 +74,24 @@ class ProfileHeader extends StatelessWidget {
             ),
             textAlign: TextAlign.center,
           ),
-          if (user.phoneNumber != null && user.phoneNumber!.isNotEmpty) ...[
-            const SizedBox(height: 4),
-            Text(
-              user.phoneNumber!,
-              style: const TextStyle(
-                fontSize: 12,
-                color: AppColors.subText,
-              ),
-              textAlign: TextAlign.center,
-            ),
-          ],
           const SizedBox(height: 16),
           Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              _certificationBadge('여권', AppColors.classTeal),
-              const SizedBox(width: 8),
-              _certificationBadge('직업', AppColors.alertOrange),
+              if (user.position != null)
+                _certificationBadge(user.positionDisplayName, AppColors.activeBlue),
+              if (user.position != null) const SizedBox(width: 8),
+              _certificationBadge(user.expLevelName, AppColors.classTeal),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: [
+              _statItem('EXP', '${user.exp}', AppColors.activeBlue),
+              _statItem('참여', '${user.participationCount}회', AppColors.classTeal),
+              _statItem('노쇼', '${user.noShowCount}회',
+                  user.noShowCount > 0 ? AppColors.errorRed : AppColors.subText),
             ],
           ),
           const SizedBox(height: 24),
@@ -116,6 +126,26 @@ class ProfileHeader extends StatelessWidget {
           ),
         ],
       ),
+    );
+  }
+
+  Widget _statItem(String label, String value, Color color) {
+    return Column(
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        ),
+        const SizedBox(height: 2),
+        Text(
+          label,
+          style: const TextStyle(fontSize: 11, color: AppColors.subText),
+        ),
+      ],
     );
   }
 


### PR DESCRIPTION
## Summary

농구 매칭 시스템을 Backend API, Flutter 프론트엔드, 백오피스 관리자 페이지 전 영역에 걸쳐 구현했습니다.

### Backend (Spring Boot)
- User 확장: `nickname`, `position`, `exp`, `noShowCount`, `participationCount` 필드 추가
- 모집글(Recruitment): 게스트/번개 모집 CRUD, 신청/수락/거절/확정/취소 API
- 경기(Match): 모집 확정 시 경기 자동 생성, 경기 완료 처리, EXP/참여횟수 반영
- 동아리 친선전(ClubMatch): 친선전 신청/참가/상대 지정/확정/결과 입력/승인 API
- 리뷰/노쇼: 경기 종료 후 따봉 리뷰 + 노쇼 신고, 관리자 확인 방식
- DB Migration: `recruitment_posts`, `matches`, `match_participations`, `club_match_requests` 등 테이블 추가

### Flutter Frontend
- 매칭 탭: 기존 홈 탭을 매칭 탭으로 교체 (게스트/번개 + 동아리 친선전 TabBar)
- 모집글: 목록(필터/진행률 바), 생성 폼(DateTimePicker/장소/형태), 상세(신청자 관리/확정/취소)
- 동아리 친선전: 목록(VS 카드), 생성 폼, 상세(상태 흐름/참가/결과)
- 리뷰 바텀시트: 경기 종료 후 참가자별 따봉/노쇼 토글
- UserModel 확장: 닉네임/포지션/EXP/노쇼/참여 횟수 표시
- 회원가입 개선: CompleteProfileScreen에 닉네임 + 포지션(가드/포워드/센터) 필수 입력 추가
- MY 탭 연동: 프로필에 포지션 뱃지, EXP 등급(루키/슈터/올스타), 통계 표시

### 백오피스 (Admin)
- 모집글 관리 탭: 모집글 목록(필터/페이지네이션) + 상세 모달(신청자 정보 포함)
- 노쇼 신고 관리 탭: 대기 목록 조회, 확정/반려 처리
- 친선전 결과 관리 탭: 승인 대기 목록, 최종 확정 처리

### 기타
- 일정 관리 개선 (훈련일정 시각화, 장소 중복 선택)
- 매칭 계획서 문서화 (`docs/MATCHING_SYSTEM_FEATURE_PLAN.md`)
- PostgreSQL ENUM 매핑, DB 스키마 동기화

## 변경 범위

- **139개 파일** 변경 (+9,639 / -313 lines)
- 신규 Entity 10개, Controller 3개, Service 4개
- Flutter 신규 화면 12개, Provider 3개, Model 3개
- 백오피스 JS 3개, 탭 3개 추가

## Test Plan

- [ ] 회원가입 → 닉네임/포지션 입력 확인
- [ ] 매칭 탭에서 모집글 목록 조회 및 필터 동작 확인
- [ ] 모집글 생성 → 신청 → 수락 → 확정 플로우 테스트
- [ ] 동아리 친선전 생성 → 참가 → 매칭 → 결과 플로우 테스트
- [ ] 경기 완료 후 리뷰 바텀시트 동작 확인
- [ ] MY 탭에서 EXP/노쇼/참여 통계 표시 확인
- [ ] 백오피스 모집글 관리 탭 조회/상세 확인
- [ ] 백오피스 노쇼 신고 확정/반려 동작 확인
- [ ] 백오피스 친선전 결과 최종 확정 동작 확인