### PR TITLE
Add verified ARM64 home-server CI/CD

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.git
+.github
+**/.gradle
+**/build
+**/.idea
+**/*.iml
+**/*.log
+**/.DS_Store
+**/.env
+**/.env.*
+**/*.pem
+**/*.key
+backend/src/test/resources/application-secret.yml
+frontend
+pict
+SPEC

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+*.sh text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+*.gradle text eol=lf
+Dockerfile text eol=lf
+gradlew text eol=lf
+*.bat text eol=crlf

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,96 +1,96 @@
-name: Deploy Backend
+name: Basketball backend CI and image publication
 
 on:
+  pull_request:
+    branches: [main]
   push:
     branches: [main]
-    paths:
-      - 'backend/**'
-      - 'docker-compose.yml'
-  workflow_dispatch:  # 수동 실행 가능
+  workflow_dispatch:
+
+permissions: {}
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}-backend
+  IMAGE_NAME: ghcr.io/blueapple031/pnubasketballplatform-backend
 
 jobs:
-  build-and-deploy:
+  test:
+    name: Test backend and migration policy
     runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+
+      - name: Set up Java 17
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5
+        with:
+          distribution: temurin
+          java-version: "17"
+          cache: gradle
+
+      - name: Validate forward-only migrations
+        run: |
+          python3 scripts/check_migrations.py --self-test
+          bash scripts/check-migrations.sh
+
+      - name: Validate fresh PostgreSQL schema bootstrap
+        run: bash scripts/check-fresh-schema.sh
+
+      - name: Run tests and build boot JAR
+        run: |
+          chmod +x gradlew
+          ./gradlew --no-daemon clean test bootJar
+
+  image:
+    name: Build immutable ARM64 image
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
-
+      attestations: write
+      id-token: write
+    outputs:
+      digest: ${{ steps.build.outputs.digest }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: 'gradle'
-
-      - name: Grant execute permission for gradlew
-        working-directory: backend
-        run: chmod +x gradlew
-
-      - name: Build JAR
-        working-directory: backend
-        run: ./gradlew bootJar --no-daemon
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract image metadata
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=raw,value=latest
-            type=sha
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
-      - name: Build and push image
-        uses: docker/build-push-action@v5
+      - name: Build and push
+        id: build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
-          context: backend
+          context: .
+          file: ./backend/Dockerfile
+          platforms: linux/arm64
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+            ${{ env.IMAGE_NAME }}:main
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          provenance: mode=max
+          sbom: true
 
-      - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.9.0
+      - name: Publish signed GitHub provenance
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-
-      - name: Copy docker-compose.yml to Server
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
-        run: |
-          mkdir -p ~/.ssh
-          ssh-keyscan -p $SSH_PORT -H $SSH_HOST >> ~/.ssh/known_hosts 2>/dev/null || true
-          scp -P $SSH_PORT -o StrictHostKeyChecking=accept-new docker-compose.yml $SSH_USER@$SSH_HOST:~/PNUBasketballPlatform/docker-compose.yml
-
-      - name: Deploy to Server
-        env:
-          SSH_HOST: ${{ secrets.SSH_HOST }}
-          SSH_USER: ${{ secrets.SSH_USER }}
-          SSH_PORT: ${{ secrets.SSH_PORT || 22 }}
-          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          ssh -o StrictHostKeyChecking=accept-new -p ${SSH_PORT:-22} $SSH_USER@$SSH_HOST \
-            "cd ~/PNUBasketballPlatform && \
-             echo '$GHCR_TOKEN' | docker login ${{ env.REGISTRY }} -u ${{ github.actor }} --password-stdin && \
-             docker compose pull backend && \
-             docker compose up -d && \
-             docker image prune -f" \
-          && echo "배포 완료"
+          subject-name: ${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+          create-storage-record: false

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,9 +1,37 @@
-FROM eclipse-temurin:17-jre-jammy
+FROM --platform=$BUILDPLATFORM eclipse-temurin:17-jdk-jammy@sha256:29467857e8bde40ab1f7befecbda0ea764b95afec1cc7f89aa90f7a766577e19 AS build
+
+WORKDIR /workspace
+
+COPY backend/gradlew gradlew
+COPY backend/gradle gradle
+COPY backend/build.gradle backend/settings.gradle ./
+RUN sed -i 's/\r$//' gradlew && \
+    chmod +x gradlew && \
+    ./gradlew --no-daemon dependencies
+
+COPY backend/src src
+RUN ./gradlew --no-daemon bootJar -x test && \
+    jar_path="$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' | head -1)" && \
+    test -n "$jar_path" && \
+    cp "$jar_path" /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-jammy@sha256:89e68b9bb83713510b63e2059a415792a7fc77e14b739a7d7ede97f6d9ca2c38 AS runtime
+
+RUN apt-get update && \
+    apt-get install --yes --no-install-recommends ca-certificates tini wget && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd --system app && \
+    useradd --system --gid app --home-dir /app app && \
+    mkdir -p /app/db/migration
 
 WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+COPY --chown=app:app docs/database/schema.sql /app/db/migration/V1__baseline_schema.sql
+COPY --chown=app:app docs/database/migrations/add_recruitment_posts.sql /app/db/migration/V2__add_recruitment_posts.sql
+COPY --chown=app:app docs/database/migrations/add_matches_and_participations.sql /app/db/migration/V3__add_matches_and_participations.sql
+COPY --chown=app:app docs/database/migrations/add_club_match_requests.sql /app/db/migration/V4__add_club_match_requests.sql
 
-COPY build/libs/*.jar app.jar
-
+USER app
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-jar", "/app/app.jar"]
+ENTRYPOINT ["/usr/bin/tini", "--", "java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,10 @@ dependencies {
     
     // Database
     runtimeOnly 'org.postgresql:postgresql'
+    // PostgreSQL 17 support starts in Flyway 10.20. Keep core and the
+    // database-specific module on the same explicitly reviewed version.
+    implementation 'org.flywaydb:flyway-core:10.20.1'
+    implementation 'org.flywaydb:flyway-database-postgresql:10.20.1'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     
     // JWT

--- a/backend/scripts/check-fresh-schema.sh
+++ b/backend/scripts/check-fresh-schema.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+set -Eeuo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repository_root="$(cd "$script_dir/../.." && pwd)"
+docker_bin="${DOCKER_BIN:-docker}"
+postgres_image=postgres:17-alpine@sha256:742f40ea20b9ff2ff31db5458d127452988a2164df9e17441e191f3b72252193
+container="basketball-schema-ci-${GITHUB_RUN_ID:-local}-$$"
+
+cleanup() {
+  "$docker_bin" rm -f -v "$container" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+for migration in \
+  docs/database/schema.sql \
+  docs/database/migrations/add_recruitment_posts.sql \
+  docs/database/migrations/add_matches_and_participations.sql \
+  docs/database/migrations/add_club_match_requests.sql; do
+  test -s "$repository_root/$migration"
+done
+
+"$docker_bin" run --detach \
+  --name "$container" \
+  --tmpfs /var/lib/postgresql/data:rw,nosuid,size=512m \
+  --env POSTGRES_USER=basketball \
+  --env POSTGRES_PASSWORD=schema-test-only \
+  --env POSTGRES_DB=basketball \
+  "$postgres_image" >/dev/null
+
+ready=false
+attempt=1
+while [ "$attempt" -le 60 ]; do
+  if "$docker_bin" exec "$container" pg_isready -U basketball -d basketball >/dev/null 2>&1; then
+    ready=true
+    break
+  fi
+  sleep 1
+  attempt=$((attempt + 1))
+done
+if [ "$ready" != true ]; then
+  echo "schema-test PostgreSQL did not become ready" >&2
+  exit 1
+fi
+
+"$docker_bin" cp "$repository_root/docs/database" "$container:/bootstrap"
+for migration in \
+  schema.sql \
+  migrations/add_recruitment_posts.sql \
+  migrations/add_matches_and_participations.sql \
+  migrations/add_club_match_requests.sql; do
+  "$docker_bin" exec "$container" psql \
+    --set ON_ERROR_STOP=1 \
+    --username basketball \
+    --dbname basketball \
+    --file "/bootstrap/$migration" >/dev/null
+done
+
+table_count="$($docker_bin exec "$container" psql \
+  --username basketball --dbname basketball --tuples-only --no-align \
+  --command "select count(*) from pg_tables where schemaname = 'public';" | tr -d '[:space:]')"
+if [ "$table_count" != 19 ]; then
+  echo "fresh schema produced unexpected public table count: $table_count" >&2
+  exit 1
+fi
+
+for table in users schedules recruitment_posts matches club_match_requests club_match_results; do
+  "$docker_bin" exec "$container" psql \
+    --username basketball --dbname basketball --tuples-only --no-align \
+    --command "select 1 from pg_tables where schemaname = 'public' and tablename = '$table';" |
+    grep -qx 1
+done
+
+echo "fresh PostgreSQL schema bootstrap passed: public_tables=$table_count"

--- a/backend/scripts/check-migrations.sh
+++ b/backend/scripts/check-migrations.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+exec python3 "$script_dir/check_migrations.py" "${1:-src/main/resources/db/migration}"

--- a/backend/scripts/check_migrations.py
+++ b/backend/scripts/check_migrations.py
@@ -1,0 +1,85 @@
+"""Enforce expand/contract-safe Flyway migrations used by automatic deploys."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+FILENAME = re.compile(r"^V[0-9]+__[A-Za-z0-9_]+\.sql$")
+BLOCK_COMMENT = re.compile(r"/\*.*?\*/", re.DOTALL)
+LINE_COMMENT = re.compile(r"--[^\n]*")
+
+UNSAFE = (
+    (re.compile(r"\b(?:DROP|TRUNCATE)\b"), "DROP/TRUNCATE requires a later contract release"),
+    (re.compile(r"\bDELETE\s+FROM\b"), "bulk DELETE is not allowed during automatic deploy"),
+    (
+        re.compile(r"\bALTER\s+TABLE\b.*\b(?:DROP|RENAME)\b"),
+        "column/table removal or rename requires a later contract release",
+    ),
+    (
+        re.compile(
+            r"\bALTER\s+TABLE\b.*\bALTER\s+(?:COLUMN\s+)?[^\s]+\s+"
+            r"(?:TYPE|SET\s+DATA\s+TYPE|SET\s+NOT\s+NULL)\b"
+        ),
+        "type or NOT NULL changes require a separately verified contract release",
+    ),
+    (
+        re.compile(
+            r"\bALTER\s+TABLE\b.*\bADD\s+(?:CONSTRAINT|FOREIGN\s+KEY|PRIMARY\s+KEY|UNIQUE|CHECK)\b"
+        ),
+        "immediate constraint addition is unsafe for an automatic deploy",
+    ),
+    (
+        re.compile(r"\bCREATE\s+UNIQUE\s+INDEX\b"),
+        "unique index creation requires a separately verified migration",
+    ),
+)
+
+
+def normalize(sql: str) -> str:
+    without_comments = LINE_COMMENT.sub(" ", BLOCK_COMMENT.sub(" ", sql))
+    return " ".join(without_comments.upper().split())
+
+
+def problems_for_sql(sql: str) -> list[str]:
+    normalized = normalize(sql)
+    return [message for pattern, message in UNSAFE if pattern.search(normalized)]
+
+
+def check_directory(root: Path) -> list[str]:
+    problems: list[str] = []
+    if not root.is_dir():
+        return problems
+    for migration in sorted(root.glob("*.sql")):
+        if not FILENAME.fullmatch(migration.name):
+            problems.append(f"{migration}: invalid Flyway migration filename")
+        for problem in problems_for_sql(migration.read_text(encoding="utf-8")):
+            problems.append(f"{migration}: {problem}")
+    return problems
+
+
+def self_test() -> None:
+    assert problems_for_sql("ALTER TABLE users ADD COLUMN display_name text") == []
+    assert problems_for_sql("-- DROP TABLE ignored_comment\nALTER TABLE users ADD COLUMN age int") == []
+    assert problems_for_sql("ALTER TABLE users DROP COLUMN name")
+    assert problems_for_sql("ALTER TABLE users ALTER COLUMN name SET NOT NULL")
+    assert problems_for_sql("ALTER TABLE child ADD CONSTRAINT fk FOREIGN KEY (id) REFERENCES parent(id)")
+    assert problems_for_sql("CREATE UNIQUE INDEX users_email_key ON users(email)")
+
+
+def main() -> int:
+    if len(sys.argv) == 2 and sys.argv[1] == "--self-test":
+        self_test()
+        return 0
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else "src/main/resources/db/migration")
+    problems = check_directory(root)
+    if problems:
+        print("\n".join(problems), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
+++ b/backend/src/main/java/com/pnu/basketball/config/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**", "/api/health").permitAll()
+                        .requestMatchers("/api/auth/**", "/api/health", "/api/health/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/clubs").permitAll()
                         .requestMatchers(
                                 "/swagger-ui/**",

--- a/backend/src/main/java/com/pnu/basketball/controller/HealthCheckController.java
+++ b/backend/src/main/java/com/pnu/basketball/controller/HealthCheckController.java
@@ -1,12 +1,17 @@
 package com.pnu.basketball.controller;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataAccessException;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 @RestController
@@ -14,26 +19,62 @@ import java.util.Map;
 public class HealthCheckController {
 
     private final LocalDateTime startTime = LocalDateTime.now();
+    private final JdbcTemplate jdbcTemplate;
+    private final RedisConnectionFactory redisConnectionFactory;
+    private final String release;
+
+    public HealthCheckController(
+            JdbcTemplate jdbcTemplate,
+            RedisConnectionFactory redisConnectionFactory,
+            @Value("${app.release:unknown}") String release) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.redisConnectionFactory = redisConnectionFactory;
+        this.release = release;
+    }
 
     @GetMapping("/health")
     public ResponseEntity<Map<String, Object>> healthCheck() {
-        Map<String, Object> response = new HashMap<>();
-        response.put("status", "UP");
-        response.put("timestamp", LocalDateTime.now());
-        response.put("service", "PNU Basketball Platform");
-        response.put("version", "1.0.0");
-        response.put("startTime", startTime);
-        
-        return ResponseEntity.ok(response);
+        return readiness();
     }
 
-    @GetMapping("/status")
-    public ResponseEntity<Map<String, String>> getStatus() {
-        Map<String, String> status = new HashMap<>();
-        status.put("server", "running");
-        status.put("database", "connected");
-        status.put("environment", "AWS EC2");
-        
-        return ResponseEntity.ok(status);
+    @GetMapping("/health/live")
+    public ResponseEntity<Map<String, Object>> liveness() {
+        return ResponseEntity.ok(baseResponse("UP"));
+    }
+
+    @GetMapping("/health/ready")
+    public ResponseEntity<Map<String, Object>> readiness() {
+        Map<String, Object> response = baseResponse("UP");
+
+        try {
+            Integer databaseResult = jdbcTemplate.queryForObject("SELECT 1", Integer.class);
+            if (databaseResult == null || databaseResult != 1) {
+                throw new IllegalStateException("unexpected database readiness result");
+            }
+            response.put("database", "UP");
+
+            try (RedisConnection connection = redisConnectionFactory.getConnection()) {
+                String pong = connection.ping();
+                if (!"PONG".equalsIgnoreCase(pong)) {
+                    throw new IllegalStateException("unexpected Redis readiness result");
+                }
+            }
+            response.put("redis", "UP");
+            return ResponseEntity.ok(response);
+        } catch (DataAccessException | IllegalStateException exception) {
+            response.put("status", "DOWN");
+            response.put("dependencies", "UNAVAILABLE");
+            return ResponseEntity.status(503).body(response);
+        }
+    }
+
+    private Map<String, Object> baseResponse(String status) {
+        Map<String, Object> response = new LinkedHashMap<>();
+        response.put("status", status);
+        response.put("timestamp", LocalDateTime.now());
+        response.put("service", "PNU Basketball Platform");
+        response.put("release", release);
+        response.put("startTime", startTime);
+        return response;
     }
 }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,22 @@
+app:
+  token-storage: redis
+  release: ${RELEASE_COMMIT:unknown}
+
+spring:
+  flyway:
+    enabled: true
+    locations: filesystem:/app/db/migration,classpath:db/migration
+    baseline-on-migrate: ${FLYWAY_BASELINE_ON_MIGRATE:false}
+    baseline-version: "100"
+    validate-on-migrate: true
+    clean-disabled: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+
+logging:
+  level:
+    root: INFO
+    com.pnu.basketball: INFO
+    org.springframework.web: INFO
+    org.springframework.security: WARN

--- a/backend/src/main/resources/db/migration/README.md
+++ b/backend/src/main/resources/db/migration/README.md
@@ -1,0 +1,11 @@
+# Versioned database migrations
+
+The existing production database is adopted at Flyway baseline version `100`.
+New migrations start at `V101` and must remain backward-compatible with both
+Blue and Green application versions during the rollback window.
+
+Use names such as `V101__add_example_column.sql`. Automatic deploys permit only
+backward-compatible expansion. Destructive changes (`DROP`, `TRUNCATE`, rename,
+type/`NOT NULL` changes, bulk delete, immediate constraints, and unique indexes)
+require a separately reviewed contract release after all application versions
+have stopped using the old schema. The CI policy intentionally fails closed.


### PR DESCRIPTION
## Summary

- replace SSH push deployment with GitHub-hosted Linux/ARM64 image publication
- publish immutable GHCR digests with SBOM and signed provenance
- add forward-only Flyway migration policy and fresh PostgreSQL schema validation
- add dependency-aware readiness checks for safe Blue/Green cutover

## Verification

- local Gradle tests and bootJar passed
- migration policy self-test passed
- V1-V4 bootstrapped successfully on isolated PostgreSQL 17
- GitHub PR check must pass before merge

This PR prepares the minimal, pull-based Mac mini production activation. It does not directly connect GitHub Actions to the home server.